### PR TITLE
Add rich tests to validate against. Write validations to make the tests pass.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ MANIFEST
 swagger_spec_validator.egg-info
 .coverage
 docs/build
+*.swp

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -11,7 +11,7 @@ def wrap_exception(method):
         try:
             method(*args, **kwargs)
         except Exception as e:
-            raise SwaggerValidationError(e.message), None, sys.exc_info()[2]
+            raise SwaggerValidationError(str(e)), None, sys.exc_info()[2]
     return wrapper
 
 

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -1,9 +1,21 @@
+import sys
+
 import json
 from jsonschema import RefResolver
 import jsonschema
 from pkg_resources import resource_filename
 
 
+def wrap_exception(method):
+    def wrapper(*args, **kwargs):
+        try:
+            method(*args, **kwargs)
+        except Exception as e:
+            raise SwaggerValidationError(e.message), None, sys.exc_info()[2]
+    return wrapper
+
+
+@wrap_exception
 def validate_json(json_document, schema_path):
     """Validate a json document against a json schema.
 

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -32,6 +32,7 @@ def validate_spec(spec_json):
     """
     validate_json(spec_json, 'schemas/v2.0/schema.json')
 
+    # TODO: Extract 'parameters', 'responses' from the spec as well.
     apis, definitions = spec_json['paths'], spec_json['definitions']
 
     validate_apis(apis)

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -1,8 +1,9 @@
 import json
 import logging
+import string
 import urllib2
 
-from swagger_spec_validator.common import validate_json
+from swagger_spec_validator.common import validate_json, SwaggerValidationError
 
 log = logging.getLogger(__name__)
 
@@ -21,5 +22,108 @@ def validate_spec_url(spec_url):
 
 
 def validate_spec(spec_json):
+    """Validates a Swagger 2.0 API Specification given a Swagger Spec.
+
+    :param spec_json: the json dict of the swagger spec.
+    :type spec_json: dict
+    :returns: `None` in case of success, otherwise raises an exception.
+    :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
+    :raises: :py:class:`jsonschema.exceptions.ValidationError`
+    """
     validate_json(spec_json, 'schemas/v2.0/schema.json')
-    # TODO: rich schema validation
+
+    apis, definitions = spec_json['paths'], spec_json['definitions']
+
+    validate_apis(apis)
+
+    validate_definitions(definitions)
+
+
+def validate_apis(apis):
+    """Validates the semantic errors in `paths` of the Spec.
+
+    :param apis: dict of all the paths
+    :returns: `None` in case of success, otherwise raises an exception.
+    :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
+    :raises: :py:class:`jsonschema.exceptions.ValidationError`
+    """
+    for api_name, api_body in apis.iteritems():
+        api_params = api_body.get('parameters', [])
+        validate_duplicate_param(api_params)
+        for oper_name in api_body:
+            oper_body = api_body[oper_name]
+            oper_params = oper_body.get('parameters', [])
+            validate_duplicate_param(oper_params)
+            all_path_params = list(set(get_path_param_names(api_params) +
+                                       get_path_param_names(oper_params)))
+            validate_unresolvable_path_params(api_name, all_path_params)
+
+
+def validate_definitions(definitions):
+    """Validates the semantic errors in `definitions` of the Spec.
+
+    :param apis: dict of all the definitions
+    :returns: `None` in case of success, otherwise raises an exception.
+    :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
+    :raises: :py:class:`jsonschema.exceptions.ValidationError`
+    """
+    for def_name in definitions:
+        definition = definitions[def_name]
+        required = definition.get('required', [])
+        props = definition.get('properties', {}).keys()
+        extra_props = list(set(required) - set(props))
+        msg = "Required list has properties not defined"
+        if extra_props:
+            raise SwaggerValidationError("%s: %s" % (msg, extra_props))
+
+
+def get_path_param_names(params):
+    """Fetch all the names of the path parameters of an operation
+
+    :param params: list of all the params
+    :returns: list of the name of the path params
+    """
+    return [param['name']
+            for param in params
+            if param['in'] == 'path']
+
+
+def validate_duplicate_param(params):
+    """Validate no duplicate parameters are present.
+    Uniqueness is determined by the combination of 'name' and 'in'.
+
+    :param params: list of all the params
+    :returns: `None` in case of success, otherwise raises an exception.
+    :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
+    """
+    seen = set()
+    msg = "Duplicate param found with (name, in)"
+    for param in params:
+        param_id = (param['name'], param['in'])
+        if param_id in seen:
+            raise SwaggerValidationError("%s: %s" % (msg, param_id))
+        seen.add(param_id)
+
+
+def get_path_params_from_url(path):
+    """Parse the path parameters from a path string
+    :param path: path url to parse for parameters
+    :returns: List of path parameter names
+    """
+    formatter = string.Formatter()
+    path_params = [item[1] for item in formatter.parse(path)]
+    return filter(None, path_params)
+
+
+def validate_unresolvable_path_params(path_name, path_params):
+    """Validate that every path parameter listed is also defined.
+
+    :param path_name: complete path name as a string.
+    :param path_params: Names of all the eligible path parameters
+    :returns: `None` in case of success, otherwise raises an exception.
+    :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
+    """
+    msg = "Path Parameter used is not defined"
+    for path in get_path_params_from_url(path_name):
+        if path not in path_params:
+            raise SwaggerValidationError("%s: %s" % (msg, path))

--- a/tests/common/validate_json_test.py
+++ b/tests/common/validate_json_test.py
@@ -2,9 +2,7 @@ import json
 import os
 import pytest
 
-from jsonschema.exceptions import ValidationError
-
-from swagger_spec_validator.common import validate_json
+from swagger_spec_validator.common import SwaggerValidationError, validate_json
 
 
 def test_success():
@@ -15,5 +13,5 @@ def test_success():
 
 
 def test_failure():
-    with pytest.raises(ValidationError):
+    with pytest.raises(SwaggerValidationError):
         validate_json({}, 'schemas/v2.0/schema.json')

--- a/tests/validator20/validate_rich_spec_test.py
+++ b/tests/validator20/validate_rich_spec_test.py
@@ -1,0 +1,76 @@
+import json
+import pytest
+
+from swagger_spec_validator.common import SwaggerValidationError
+from swagger_spec_validator.validator20 import validate_spec
+
+
+@pytest.fixture
+def swagger_spec(petstore_contents):
+    return json.loads(petstore_contents)
+
+
+def test_failure_on_duplicate_api_parameters(swagger_spec):
+    param1 = {"name": "foo", "in": "query", "type": "string"}
+    param2 = {"name": "foo", "in": "query", "type": "integer"}
+    swagger_spec['paths']['/pet']['parameters'] = [param1, param2]
+    with pytest.raises(SwaggerValidationError) as exc_info:
+        validate_spec(swagger_spec)
+    assert("Duplicate param found with (name, in): ('foo', 'query')"
+           in exc_info.value)
+
+
+def test_failure_on_duplicate_operation_parameters(swagger_spec):
+    param1 = {"name": "foo", "in": "query", "type": "string"}
+    param2 = {"name": "foo", "in": "query", "type": "integer"}
+    swagger_spec['paths']['/pet']['post']['parameters'].extend([param1, param2])
+    with pytest.raises(SwaggerValidationError) as exc_info:
+        validate_spec(swagger_spec)
+    assert("Duplicate param found with (name, in): ('foo', 'query')"
+           in exc_info.value)
+
+
+def test_failure_on_unresolvable_path_parameter(swagger_spec):
+    swagger_spec['paths']['/pet/{foo}'] = swagger_spec['paths']['/pet']
+    with pytest.raises(SwaggerValidationError) as exc_info:
+        validate_spec(swagger_spec)
+    assert("Path Parameter used is not defined: foo" in exc_info.value)
+
+
+def test_failure_on_path_parameter_used_but_not_defined(swagger_spec):
+    swagger_spec['paths']['/user/{username}']['get']['parameters'][0]['name'] = '_'
+    with pytest.raises(SwaggerValidationError) as exc_info:
+        validate_spec(swagger_spec)
+    assert("Path Parameter used is not defined: username" in exc_info.value)
+
+
+def test_failure_on_unresolvable_ref_of_props_required_list(swagger_spec):
+    swagger_spec['definitions']['Pet']['required'].append('bla')
+    with pytest.raises(SwaggerValidationError) as exc_info:
+        validate_spec(swagger_spec)
+    assert "Required list has properties not defined: ['bla']" in exc_info.value
+
+# TODO: validate definitions of references made by $ref, commented them for now.
+"""
+def test_failure_on_unresolvable_model_reference_from_model(swagger_spec):
+    swagger_spec['definitions']['Pet']['properties']['category']['$ref'] = '_'
+    with pytest.raises(SwaggerValidationError):
+        validate_spec(swagger_spec)
+
+
+def test_failure_on_unresolvable_model_reference_from_param(swagger_spec):
+    param = swagger_spec['paths']['/pet']['post']['parameters'][0]
+    param['schema']['$ref'] = '#/definitions/bla'
+    with pytest.raises(SwaggerValidationError):
+        validate_spec(swagger_spec)
+
+
+def test_failure_on_unresolvable_model_reference_from_resp(swagger_spec):
+    resp = swagger_spec['paths']['/pet/findByStatus']['get']['responses']
+    resp['200']['schema']['items']['$ref'] = '#/definitions/bla'
+    with pytest.raises(SwaggerValidationError):
+        validate_spec(swagger_spec)
+"""
+
+# TODO: Add warning validations for unused models, path parameter & responses
+# TODO: Add validations for cyclic model definitions


### PR DESCRIPTION
As of now, commented out the tests to validate the references made by $ref. Need to find a good way to validate these. `jsonschema` doesn't support validations of '$ref' on json instance (but on json schema).

Following (checked) are covered:

Errors:
- [ ] Exactly duplicate api path [_Not possible on json dict_]
- [x] duplicate parameter (path)
- [x] duplicate parameter (operation)

- [x] unresolvable API parameter (listed as path param in endpoint name, but not defined in params)
- [ ] unresolvable model (refering a undefined model from model definition)
- [ ] unresolvable model (refering a undefined model from parameter)
- [ ] unresolvable model (refering a undefined model from response)

- [x] missing definition of required model property

Warnings:
- [ ] unused model
- [ ] unused path parameter
- [ ] unused response

Good to check:
- [ ] cyclical model inheritance

Edit:
Some more validations:
Errors:
- [ ] duplicate api path by path types i.e. /pet/{petId} and /pet/{id}
- [ ] 'items' be mandatory if type is 'array'
- [ ] validating type of 'default' property.
- [ ] unresolvable parameter (refering a parameter not defined in [`#/parameters`](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#parametersDefinitionsObject))
- [ ] Similar to above for responses.