### PR TITLE
Support File type

### DIFF
--- a/tests/validator12/validate_spec_test.py
+++ b/tests/validator12/validate_spec_test.py
@@ -2,9 +2,14 @@ import json
 import os
 
 import mock
+import pytest
 
 from .validate_spec_url_test import make_mock_responses, read_contents
-from swagger_spec_validator.validator12 import validate_spec
+from swagger_spec_validator.common import SwaggerValidationError
+from swagger_spec_validator.validator12 import (
+    validate_spec,
+    validate_parameter,
+)
 
 
 RESOURCE_LISTING_FILE = os.path.abspath('tests/data/v1.2/foo/swagger_api.json')
@@ -35,3 +40,24 @@ def test_file_uri_success():
 
         expected = json.load(read_contents(API_DECLARATION_FILE))
         mock_api.assert_called_once_with(expected)
+
+
+def test_validate_parameter_type_file_in_form():
+    parameter = {
+        'paramType': 'form',
+        'name': 'what',
+        'type': 'File',
+    }
+    # lack of errors is success
+    validate_parameter(parameter, [])
+
+
+def test_validate_parameter_type_file_in_body():
+    parameter = {
+        'paramType': 'body',
+        'name': 'what',
+        'type': 'File',
+    }
+    with pytest.raises(SwaggerValidationError) as exc:
+        validate_parameter(parameter, [])
+    assert 'Type "File" is only valid for form parameters' in str(exc)


### PR DESCRIPTION
https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#43-data-types

I don't  see an easy way to do the extra assertions about being in params and type form. The warning comes right from the spec: https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#435-file