### PR TITLE
Sync 2.0 spec with the latest from upstream

### DIFF
--- a/swagger_spec_validator/schemas/v2.0/schema.json
+++ b/swagger_spec_validator/schemas/v2.0/schema.json
@@ -214,7 +214,6 @@
     },
     "mimeType": {
       "type": "string",
-      "pattern": "^[\\sa-z0-9\\-+;\\.=\\/]+$",
       "description": "The MIME type of the HTTP message."
     },
     "operation": {
@@ -605,6 +604,11 @@
           "type": "string",
           "description": "The name of the parameter."
         },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
         "type": {
           "type": "string",
           "enum": [
@@ -692,6 +696,11 @@
         "name": {
           "type": "string",
           "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
         },
         "type": {
           "type": "string",
@@ -945,6 +954,9 @@
         "enum": {
           "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
         },
+        "additionalProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/additionalProperties"
+        },
         "type": {
           "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
         },
@@ -991,7 +1003,8 @@
           "$ref": "#/definitions/externalDocs"
         },
         "example": {}
-      }
+      },
+      "additionalProperties": false
     },
     "primitivesItems": {
       "type": "object",


### PR DESCRIPTION
Syncing to bring in support for `additionalProperties` on object types - See https://github.com/swagger-api/swagger-spec/issues/285