### PR TITLE
Remove "id" from swagger json schema - for some reason, the json schema ...

### DIFF
--- a/swagger_spec_validator/schemas/v2.0/schema.json
+++ b/swagger_spec_validator/schemas/v2.0/schema.json
@@ -1,6 +1,5 @@
 {
   "title": "A JSON Schema for Swagger 2.0 API.",
-  "id": "http://swagger.io/v2/schema.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [


### PR DESCRIPTION
...is downloaded from the url in id (hence an older schema without the min params fix) which causes breakage.  Fixes #23 