### PR TITLE
Fix mock version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,9 @@ envlist = py26,py27,py26-simplejson,py33,py34
 
 [testenv]
 deps =
-    # Pin a pre-release version of jsonschema with a fix for py3.x
-    # Remove this once jsonschema > 2.4.0 is released
-    git+https://github.com/Julian/jsonschema.git@168237288#egg=jsonschema
+    jsonschema
     flake8
-    mock
+    mock<1.1.0
     pytest
 commands =
     py.test {posargs:tests}


### PR DESCRIPTION
- Currently failing on yelp's jenkins. Using mock pinning similar to `bravado` and `bravado-core`.