### PR TITLE
Fix missing x-scope when rich validations try to deref $refs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.0.1 (2015-11-17)
+------------------
+- Fix rich validations that rely on a working deref with scope annotations
+
 2.0.0 (2015-11-17)
 ------------------
 - Support for recursive $refs

--- a/swagger_spec_validator/ref_validators.py
+++ b/swagger_spec_validator/ref_validators.py
@@ -165,8 +165,8 @@ def attach_scope(ref_dict, instance_resolver):
     resolved by custom validations done outside the scope of jsonscema
     validations.
 
-    :param ref_dict:
-    :param instance_resolver:
+    :param ref_dict: dict with $ref key
+    :type instance_resolver: :class:`jsonschema.validators.RefResolver`
     """
     if 'x-scope' in ref_dict:
         log.debug('Ref %s already has scope attached' % ref_dict['$ref'])
@@ -181,7 +181,7 @@ def in_scope(resolver, ref_dict):
 
     The resolver's original scope is restored when exiting the context manager.
 
-    :type resolver: :class:`jsonschama.validators.RefResolver
+    :type resolver: :class:`jsonschema.validators.RefResolver
     :type ref_dict: dict
     """
     if 'x-scope' not in ref_dict:

--- a/swagger_spec_validator/ref_validators.py
+++ b/swagger_spec_validator/ref_validators.py
@@ -144,6 +144,10 @@ def deref_and_validate(validator, schema_element, instance, schema,
         if ref in visited_refs:
             log.debug("Found cycle in %s" % ref)
             return
+
+        # Annotate $ref dict with scope - used by custom validations
+        attach_scope(instance, instance_resolver)
+
         with visiting(visited_refs, ref):
             with instance_resolver.resolving(ref) as target:
                 for error in default_validator_callable(
@@ -154,3 +158,38 @@ def deref_and_validate(validator, schema_element, instance, schema,
         for error in default_validator_callable(
                 validator, schema_element, instance, schema):
             yield error
+
+
+def attach_scope(ref_dict, instance_resolver):
+    """Attach scope to each $ref we encounter so that the $ref can be
+    resolved by custom validations done outside the scope of jsonscema
+    validations.
+
+    :param ref_dict:
+    :param instance_resolver:
+    """
+    if 'x-scope' in ref_dict:
+        log.debug('Ref %s already has scope attached' % ref_dict['$ref'])
+        return
+    log.debug('Attaching x-scope to {0}'.format(ref_dict))
+    ref_dict['x-scope'] = list(instance_resolver._scopes_stack)
+
+
+@contextlib.contextmanager
+def in_scope(resolver, ref_dict):
+    """Context manager to assume the given scope for the passed in resolver.
+
+    The resolver's original scope is restored when exiting the context manager.
+
+    :type resolver: :class:`jsonschama.validators.RefResolver
+    :type ref_dict: dict
+    """
+    if 'x-scope' not in ref_dict:
+        yield
+    else:
+        saved_scope_stack = resolver._scopes_stack
+        try:
+            resolver._scopes_stack = ref_dict['x-scope']
+            yield
+        finally:
+            resolver._scopes_stack = saved_scope_stack

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -8,7 +8,7 @@ from swagger_spec_validator.common import load_json
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.common import validate_json
 from swagger_spec_validator.common import wrap_exception
-
+from swagger_spec_validator.ref_validators import in_scope
 
 log = logging.getLogger(__name__)
 
@@ -29,9 +29,10 @@ def deref(ref_dict, resolver):
         return ref_dict
 
     ref = ref_dict['$ref']
-    with resolver.resolving(ref) as target:
-        log.debug('Resolving {0}'.format(ref))
-        return target
+    with in_scope(resolver, ref_dict):
+        with resolver.resolving(ref) as target:
+            log.debug('Resolving {0}'.format(ref))
+            return target
 
 
 @wrap_exception

--- a/tests/data/v2.0/test_complicated_refs/definitions/definitions.json
+++ b/tests/data/v2.0/test_complicated_refs/definitions/definitions.json
@@ -1,0 +1,10 @@
+{
+  "pong": {
+      "type": "object",
+      "properties": {
+          "pang": {
+              "type": "string"
+          }
+      }
+  }
+}

--- a/tests/data/v2.0/test_complicated_refs/operations/operations.json
+++ b/tests/data/v2.0/test_complicated_refs/operations/operations.json
@@ -1,0 +1,20 @@
+{
+  "ping": {
+      "get": {
+        "tags": [
+            "pingpong"
+        ],
+        "operationId": "ping",
+        "parameters": [
+            {
+                "$ref": "../parameters/parameters.json#/pung"
+            }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "../responses/responses.json#/pong"
+          }
+        }
+      }
+    }
+}

--- a/tests/data/v2.0/test_complicated_refs/parameters/parameters.json
+++ b/tests/data/v2.0/test_complicated_refs/parameters/parameters.json
@@ -1,0 +1,8 @@
+{
+    "pung": {
+        "name": "pung",
+        "in": "query",
+        "description": "true or false",
+        "type": "boolean"
+    }
+}

--- a/tests/data/v2.0/test_complicated_refs/paths/paths.json
+++ b/tests/data/v2.0/test_complicated_refs/paths/paths.json
@@ -1,0 +1,7 @@
+{
+  "ping": {
+    "get": {
+      "$ref": "../operations/operations.json#/ping/get"
+    }
+  }
+}

--- a/tests/data/v2.0/test_complicated_refs/responses/responses.json
+++ b/tests/data/v2.0/test_complicated_refs/responses/responses.json
@@ -1,0 +1,8 @@
+{
+    "pong": {
+        "description": "pong",
+        "schema": {
+          "$ref": "../definitions/definitions.json#/pong"
+        }
+    }
+}

--- a/tests/data/v2.0/test_complicated_refs/swagger.json
+++ b/tests/data/v2.0/test_complicated_refs/swagger.json
@@ -1,0 +1,23 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Simple"
+  },
+  "tags": [
+      {
+          "name": "pingpong",
+          "description": "pingpong related specs"
+      }
+  ],
+  "paths": {
+    "/ping": {
+        "$ref": "paths/paths.json#/ping"
+    }
+  },
+  "definitions": {
+      "pong": {
+          "$ref": "definitions/definitions.json#/pong"
+      }
+  }
+}

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -3,6 +3,7 @@ import os
 
 from jsonschema.validators import RefResolver
 import pytest
+from six.moves.urllib import parse as urlparse
 
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator20 import validate_spec
@@ -126,3 +127,29 @@ def test_recursive_ref_failure(minimal_swagger_dict, node_spec):
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec(minimal_swagger_dict)
     assert 'Unresolvable JSON pointer' in str(excinfo.value)
+
+
+def test_complicated_refs():
+
+    def get_spec_json_and_url(rel_url):
+        my_dir = os.path.abspath(os.path.dirname(__file__))
+        abs_path = os.path.join(my_dir, rel_url)
+        with open(abs_path) as f:
+            return json.loads(f.read()), urlparse.urljoin('file:', abs_path)
+
+    # Split the swagger spec into a bunch of different json files and use
+    # $refs all over to place to wire stuff together - see the test-data
+    # files or this will make no sense whatsoever.
+    file_path = '../../tests/data/v2.0/test_complicated_refs/swagger.json'
+    swagger_dict, origin_url = get_spec_json_and_url(file_path)
+    resolver = validate_spec(swagger_dict, spec_url=origin_url)
+
+    # Hokey verification but better than nothing:
+    #   If all the files with $refs were ingested and validated and an
+    #   exception was not thrown, there should be 8 cached refs in the
+    #   resolver's store:
+    #
+    #   6 json files from ../../tests/data/v2.0/tests_complicated_refs/*
+    #   1 draft3 spec
+    #   1 draft4 spec
+    assert len(resolver.store) == 8


### PR DESCRIPTION
This bug slipped through the 2.0.0 release - rich validation dereffing was broken because resolver scope wasn't attached to the $ref.