### PR TITLE
Ignore "operations" starting with "x-"

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -145,7 +145,7 @@ def validate_apis(apis, deref):
         for oper_name in api_body:
             # don't treat parameters that apply to all api operations as
             # an operation
-            if oper_name == 'parameters':
+            if oper_name == 'parameters' or oper_name.startswith('x-'):
                 continue
             oper_body = deref(api_body[oper_name])
             oper_params = deref(oper_body.get('parameters', []))

--- a/tests/validator20/validate_apis_test.py
+++ b/tests/validator20/validate_apis_test.py
@@ -7,7 +7,6 @@ def test_api_level_params_ok():
     # since they are peers.
     apis = {
         '/tags/{tag-name}': {
-            'x-ignore-me': 'DO NOT LOOK AT ME!',
             'parameters': [
                 {
                     'name': 'tag-name',
@@ -16,6 +15,26 @@ def test_api_level_params_ok():
                 },
             ],
             'get': {
+            }
+        }
+    }
+    # Success == no exception thrown
+    validate_apis(apis, lambda x: x)
+
+
+def test_api_level_x_hyphen_ok():
+    # Elements starting with "x-" should be ignored
+    apis = {
+        '/tags/{tag-name}': {
+            'x-ignore-me': 'DO NOT LOOK AT ME!',
+            'get': {
+                'parameters': [
+                    {
+                        'name': 'tag-name',
+                        'in': 'path',
+                        'type': 'string',
+                    }
+                ]
             }
         }
     }

--- a/tests/validator20/validate_apis_test.py
+++ b/tests/validator20/validate_apis_test.py
@@ -7,6 +7,7 @@ def test_api_level_params_ok():
     # since they are peers.
     apis = {
         '/tags/{tag-name}': {
+            'x-ignore-me': 'DO NOT LOOK AT ME!',
             'parameters': [
                 {
                     'name': 'tag-name',


### PR DESCRIPTION
According to the [Swagger 2.0 spec](http://swagger.io/specification/#pathsObject), paths may include elements starting with `x-`, for vendor extensions. [Apiary](https://help.apiary.io/api_101/swagger-extensions/) depends on this for path-level own summary and description nodes

This change simply ignored elements at the path level starting with `x-`, as it does path parameters.