### PR TITLE
Extend parameter definition support in swagger 2.0

### DIFF
--- a/swagger_spec_validator/schemas/v2.0/schema.json
+++ b/swagger_spec_validator/schemas/v2.0/schema.json
@@ -912,6 +912,9 @@
         },
         {
           "$ref": "#/definitions/nonBodyParameter"
+        },
+        {
+          "$ref": "#/definitions/schema"
         }
       ]
     },


### PR DESCRIPTION
Handles the case described in #47 where a parameter can't be specified as a schema.