### PR TITLE
Attempt to load relative references as YAML if JSON fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'jsonschema',
         'setuptools',
         'six',
+        'pyyaml'
     ],
     license=about['__license__']
 )

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -6,6 +6,9 @@ try:
 except ImportError:
     import json
 import six
+import yaml
+from jsonschema import RefResolver as BaseRefResolver
+from jsonschema.compat import urlopen
 from six.moves.urllib import request
 
 TIMEOUT_SEC = 1
@@ -31,3 +34,16 @@ def load_json(url):
 class SwaggerValidationError(Exception):
     """Exception raised in case of a validation error."""
     pass
+
+
+class RefResolver(BaseRefResolver):
+
+    def resolve_remote(self, uri):
+        try:
+            return super(RefResolver, self).resolve_remote(uri)
+        except ValueError:
+            result = yaml.safe_load(urlopen(uri).read().decode('utf-8'))
+
+        if self.cache_remote:
+            self.store[uri] = result
+        return result

--- a/swagger_spec_validator/validator12.py
+++ b/swagger_spec_validator/validator12.py
@@ -16,11 +16,11 @@ import logging
 import os
 
 import jsonschema
-from jsonschema import RefResolver
 from pkg_resources import resource_filename
 import six
 from six.moves.urllib.parse import urlparse
 
+from swagger_spec_validator.common import RefResolver
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.common import load_json
 from swagger_spec_validator.common import wrap_exception

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -6,13 +6,13 @@ except ImportError:
 import logging
 import string
 
-from jsonschema import RefResolver
 from jsonschema.validators import Draft4Validator
 from pkg_resources import resource_filename
 from six import iteritems
 
 
 from swagger_spec_validator import ref_validators
+from swagger_spec_validator.common import RefResolver
 from swagger_spec_validator.common import load_json
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.common import wrap_exception

--- a/tests/data/v2.0/test_complicated_refs/definitions/pet.yaml
+++ b/tests/data/v2.0/test_complicated_refs/definitions/pet.yaml
@@ -1,0 +1,4 @@
+type: object
+properties:
+  name:
+    type: string

--- a/tests/data/v2.0/test_complicated_refs/swagger.json
+++ b/tests/data/v2.0/test_complicated_refs/swagger.json
@@ -18,6 +18,9 @@
   "definitions": {
       "pong": {
           "$ref": "definitions/definitions.json#/pong"
+      },
+      "pet": {
+          "$ref": "definitions/pet.yaml"
       }
   }
 }

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -149,7 +149,7 @@ def test_complicated_refs():
     #   exception was not thrown, there should be 8 cached refs in the
     #   resolver's store:
     #
-    #   6 json files from ../../tests/data/v2.0/tests_complicated_refs/*
+    #   7 json files from ../../tests/data/v2.0/tests_complicated_refs/*
     #   1 draft3 spec
     #   1 draft4 spec
-    assert len(resolver.store) == 8
+    assert len(resolver.store) == 9


### PR DESCRIPTION
Wrap jsonschema.RefResolver.resolve_remote to attempt to load files as yaml if they can't be loaded as json. This allows validating specs split up across multiple files to include .yaml files.
