### PR TITLE
Fix the build

### DIFF
--- a/tests/validator20/validate_rich_spec_test.py
+++ b/tests/validator20/validate_rich_spec_test.py
@@ -51,6 +51,7 @@ def test_failure_on_unresolvable_ref_of_props_required_list(swagger_spec):
     assert ("Required list has properties not defined: ['bla']"
             in str(exc_info.value))
 
+
 # TODO: validate definitions of references made by $ref, commented them for now.
 """
 def test_failure_on_unresolvable_model_reference_from_model(swagger_spec):


### PR DESCRIPTION
Fix the following flake8 build error:

    py34 runtests: commands[1] | flake8 .
    ./tests/validator20/validate_rich_spec_test.py:55:1: E305 expected 2 blank lines after class or function definition, found 1