### PR TITLE
did validate_spec swagger schema agnostic

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -64,8 +64,7 @@ def validate_spec_url(spec_url):
 
 
 def validate_spec(spec_dict, spec_url='', http_handlers=None,
-                  schema_pkg='swagger_spec_validator',
-                  schema_path='schemas/v2.0/schema.json'):
+                  schema_dict=None):
     """Validates a Swagger 2.0 API Specification given a Swagger Spec.
 
     :param spec_dict: the json dict of the swagger spec.
@@ -87,11 +86,10 @@ def validate_spec(spec_dict, spec_url='', http_handlers=None,
     """
     swagger_resolver = validate_json(
         spec_dict,
-        schema_pkg,
-        schema_path,
+        'schemas/v2.0/schema.json',
         spec_url=spec_url,
         http_handlers=http_handlers,
-    )
+        schema=schema_dict)
 
     bound_deref = functools.partial(deref, resolver=swagger_resolver)
     spec_dict = bound_deref(spec_dict)
@@ -103,8 +101,8 @@ def validate_spec(spec_dict, spec_url='', http_handlers=None,
 
 
 @wrap_exception
-def validate_json(spec_dict, schema_pkg, schema_path,
-                  spec_url='', http_handlers=None):
+def validate_json(spec_dict, schema_path, spec_url='',
+                  http_handlers=None, schema=None):
     """Validate a json document against a json schema.
 
     :param spec_dict: json document in the form of a list or dict.
@@ -122,8 +120,9 @@ def validate_json(spec_dict, schema_pkg, schema_path,
         validation.
     :rtype: :class:`jsonschema.RefResolver`
     """
-    schema_path = resource_filename(schema_pkg, schema_path)
-    schema = read_file(schema_path)
+    if schema is None:
+        schema_path = resource_filename('swagger_spec_validator', schema_path)
+        schema = read_file(schema_path)
 
     schema_resolver = RefResolver(
         base_uri='file://{}'.format(schema_path),

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -63,8 +63,11 @@ def validate_spec_url(spec_url):
     return validate_spec(read_url(spec_url), spec_url)
 
 
-def validate_spec(spec_dict, spec_url='', http_handlers=None,
-                  schema_dict=None):
+def validate_spec(spec_dict, spec_url='',
+                  http_handlers=None, custom_handlers=None,
+                  apis_getter=None, definitions_getter=None,
+                  apis_validator=None, definitions_validator=None,
+                  schema_dict=None, urljoin_cache=None):
     """Validates a Swagger 2.0 API Specification given a Swagger Spec.
 
     :param spec_dict: the json dict of the swagger spec.
@@ -72,53 +75,88 @@ def validate_spec(spec_dict, spec_url='', http_handlers=None,
     :param spec_url: url from which spec_dict was retrieved. Used for
         dereferencing refs. eg: file:///foo/swagger.json
     :type spec_url: string
-    :param http_handlers: used to download any remote $refs in spec_dict with
-        a custom http client. Defaults to None in which case the default
-        http client built into jsonschema's RefResolver is used. This
-        is a mapping from uri scheme to a callable that takes a
-        uri.
+    :param http_handlers: deprecated. use the 'custom_handlers' parameter
+        instead
+    :param custom_handlers: used to download any remote $refs in spec_dict
+        with a custom http client or used to add custom handlers for $refs.
+        Defaults to None in which case the default http client built into
+        jsonschema's RefResolver is used. This is a mapping from uri scheme
+        to a callable that takes a uri.
+    :param apis_getter: a callable used to get the apis from the 'paths'
+        object.
+    :param definitions_getter: a callable used to get the definitions from
+        the 'definitions' object.
+    :param apis_validator: a callable used to validate the apis specification.
+    :param definitions_validator: a callable used to validate the definitions
+        specification.
     :param schema_dict: the schema which validate the swagger specification.
+    :param urljoin_cache: a callable to be used on the
+        `jsonschema.RefResolver` constructor.
 
     :returns: the resolver (with cached remote refs) used during validation
     :rtype: :class:`jsonschema.RefResolver`
     :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
     """
+    def default_getter(obj, deref):
+        return deref(obj)
+
+    if custom_handlers is None:
+        custom_handlers = http_handlers
+
     swagger_resolver = validate_json(
         spec_dict,
         'schemas/v2.0/schema.json',
         spec_url=spec_url,
-        http_handlers=http_handlers,
-        schema=schema_dict)
+        custom_handlers=custom_handlers,
+        schema=schema_dict,
+        urljoin_cache=urljoin_cache)
+
+    apis_getter = apis_getter or default_getter
+    definitions_getter = definitions_getter or default_getter
+    apis_validator = apis_validator or validate_apis
+    definitions_validator = definitions_validator or validate_definitions
 
     bound_deref = functools.partial(deref, resolver=swagger_resolver)
+
     spec_dict = bound_deref(spec_dict)
-    apis = bound_deref(spec_dict['paths'])
-    definitions = bound_deref(spec_dict.get('definitions', {}))
-    validate_apis(apis, bound_deref)
-    validate_definitions(definitions, bound_deref)
+    apis = apis_getter(spec_dict['paths'], bound_deref)
+    definitions = definitions_getter(spec_dict.get('definitions', {}),
+                                     bound_deref)
+
+    apis_validator(apis, bound_deref)
+    definitions_validator(definitions, bound_deref)
     return swagger_resolver
 
 
 @wrap_exception
 def validate_json(spec_dict, schema_path, spec_url='',
-                  http_handlers=None, schema=None):
+                  http_handlers=None, custom_handlers=None,
+                  schema=None, urljoin_cache=None):
     """Validate a json document against a json schema.
 
     :param spec_dict: json document in the form of a list or dict.
     :param schema_path: package relative path of the json schema file.
     :param spec_url: base uri to use when creating a
         RefResolver for the passed in spec_dict.
-    :param http_handlers: used to download any remote $refs in spec_dict with
-        a custom http client. Defaults to None in which case the default
-        http client built into jsonschema's RefResolver is used. This
-        is a mapping from uri scheme to a callable that takes a
-        uri.
+    :param http_handlers: deprecated. use the 'custom_handlers' parameter
+        instead
+    :param custom_handlers: used to download any remote $refs in spec_dict
+        with a custom http client or used to add custom handlers for $refs.
+        Defaults to None in which case the default http client built into
+        jsonschema's RefResolver is used. This is a mapping from uri scheme
+        to a callable that takes a uri.
     :param schema: the schema which validate the swagger specification.
+    :type schema: dict | None
+    :param urljoin_cache: a callable to be used on the
+        `jsonschema.RefResolver` constructor.
 
     :return: RefResolver for spec_dict with cached remote $refs used during
         validation.
     :rtype: :class:`jsonschema.RefResolver`
     """
+    if custom_handlers is None:
+        custom_handlers = http_handlers
+
     if schema is None:
         schema_path = resource_filename('swagger_spec_validator', schema_path)
         schema = read_file(schema_path)
@@ -126,13 +164,15 @@ def validate_json(spec_dict, schema_path, spec_url='',
     schema_resolver = RefResolver(
         base_uri='file://{}'.format(schema_path),
         referrer=schema,
-        handlers=default_handlers,
+        handlers=custom_handlers or default_handlers,
+        urljoin_cache=urljoin_cache
     )
 
     spec_resolver = RefResolver(
         base_uri=spec_url,
         referrer=spec_dict,
-        handlers=http_handlers or default_handlers,
+        handlers=custom_handlers or default_handlers,
+        urljoin_cache=urljoin_cache
     )
 
     ref_validators.validate(

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -63,7 +63,9 @@ def validate_spec_url(spec_url):
     return validate_spec(read_url(spec_url), spec_url)
 
 
-def validate_spec(spec_dict, spec_url='', http_handlers=None):
+def validate_spec(spec_dict, spec_url='', http_handlers=None,
+                  schema_pkg='swagger_spec_validator',
+                  schema_path='schemas/v2.0/schema.json'):
     """Validates a Swagger 2.0 API Specification given a Swagger Spec.
 
     :param spec_dict: the json dict of the swagger spec.
@@ -76,6 +78,8 @@ def validate_spec(spec_dict, spec_url='', http_handlers=None):
         http client built into jsonschema's RefResolver is used. This
         is a mapping from uri scheme to a callable that takes a
         uri.
+    :param schema_pkg: package of the json schema file.
+    :param schema_path: package relative path of the json schema file.
 
     :returns: the resolver (with cached remote refs) used during validation
     :rtype: :class:`jsonschema.RefResolver`
@@ -83,7 +87,8 @@ def validate_spec(spec_dict, spec_url='', http_handlers=None):
     """
     swagger_resolver = validate_json(
         spec_dict,
-        'schemas/v2.0/schema.json',
+        schema_pkg,
+        schema_path,
         spec_url=spec_url,
         http_handlers=http_handlers,
     )
@@ -98,10 +103,12 @@ def validate_spec(spec_dict, spec_url='', http_handlers=None):
 
 
 @wrap_exception
-def validate_json(spec_dict, schema_path, spec_url='', http_handlers=None):
+def validate_json(spec_dict, schema_pkg, schema_path,
+                  spec_url='', http_handlers=None):
     """Validate a json document against a json schema.
 
     :param spec_dict: json document in the form of a list or dict.
+    :param schema_pkg: package of the json schema file.
     :param schema_path: package relative path of the json schema file.
     :param spec_url: base uri to use when creating a
         RefResolver for the passed in spec_dict.
@@ -115,7 +122,7 @@ def validate_json(spec_dict, schema_path, spec_url='', http_handlers=None):
         validation.
     :rtype: :class:`jsonschema.RefResolver`
     """
-    schema_path = resource_filename('swagger_spec_validator', schema_path)
+    schema_path = resource_filename(schema_pkg, schema_path)
     schema = read_file(schema_path)
 
     schema_resolver = RefResolver(

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -77,8 +77,7 @@ def validate_spec(spec_dict, spec_url='', http_handlers=None,
         http client built into jsonschema's RefResolver is used. This
         is a mapping from uri scheme to a callable that takes a
         uri.
-    :param schema_pkg: package of the json schema file.
-    :param schema_path: package relative path of the json schema file.
+    :param schema_dict: the schema which validate the swagger specification.
 
     :returns: the resolver (with cached remote refs) used during validation
     :rtype: :class:`jsonschema.RefResolver`
@@ -106,7 +105,6 @@ def validate_json(spec_dict, schema_path, spec_url='',
     """Validate a json document against a json schema.
 
     :param spec_dict: json document in the form of a list or dict.
-    :param schema_pkg: package of the json schema file.
     :param schema_path: package relative path of the json schema file.
     :param spec_url: base uri to use when creating a
         RefResolver for the passed in spec_dict.
@@ -115,6 +113,7 @@ def validate_json(spec_dict, schema_path, spec_url='',
         http client built into jsonschema's RefResolver is used. This
         is a mapping from uri scheme to a callable that takes a
         uri.
+    :param schema: the schema which validate the swagger specification.
 
     :return: RefResolver for spec_dict with cached remote $refs used during
         validation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,4 +8,5 @@ from __future__ import unicode_literals
 def is_urlopen_error(exception):
     return '<urlopen error [Errno -2] Name or service not known>' in str(exception) or \
            '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(exception) or \
-           '<urlopen error [Errno -5] No address associated with hostname>' in str(exception)
+           '<urlopen error [Errno -5] No address associated with hostname>' in str(exception) or \
+           '<urlopen error [Errno -3] Temporary failure in name resolution>' in str(exception)

--- a/tests/validator20/validate_json_test.py
+++ b/tests/validator20/validate_json_test.py
@@ -17,10 +17,10 @@ def test_success():
     my_dir = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(my_dir, '../data/v2.0/petstore.json')) as f:
         petstore_spec = json.load(f)
-    validate_json(petstore_spec, 'schemas/v2.0/schema.json')
+    validate_json(petstore_spec, 'swagger_spec_validator', 'schemas/v2.0/schema.json')
 
 
 def test_failure():
     with pytest.raises(SwaggerValidationError) as excinfo:
-        validate_json({}, 'schemas/v2.0/schema.json')
+        validate_json({}, 'swagger_spec_validator', 'schemas/v2.0/schema.json')
     assert "'swagger' is a required property" in str(excinfo.value)

--- a/tests/validator20/validate_json_test.py
+++ b/tests/validator20/validate_json_test.py
@@ -17,10 +17,10 @@ def test_success():
     my_dir = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(my_dir, '../data/v2.0/petstore.json')) as f:
         petstore_spec = json.load(f)
-    validate_json(petstore_spec, 'swagger_spec_validator', 'schemas/v2.0/schema.json')
+    validate_json(petstore_spec, 'schemas/v2.0/schema.json')
 
 
 def test_failure():
     with pytest.raises(SwaggerValidationError) as excinfo:
-        validate_json({}, 'swagger_spec_validator', 'schemas/v2.0/schema.json')
+        validate_json({}, 'schemas/v2.0/schema.json')
     assert "'swagger' is a required property" in str(excinfo.value)


### PR DESCRIPTION
I have my own Swagger Schema Extension (with oneOf and anyOf support) and I need this changes to use my schema to validate under yours API.