### PR TITLE
support properties through allof inheritance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ swagger_spec_validator.egg-info
 .coverage
 docs/build
 *.swp
+.cache

--- a/tests/data/v2.0/test_requires_and_allof/userapi.json
+++ b/tests/data/v2.0/test_requires_and_allof/userapi.json
@@ -4,32 +4,7 @@
         "version": "1.0.0",
         "title": "test"
     },
-    "paths": {
-        "/users/{id}": {
-            "get": {
-                "consumes": [],
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/User"
-                        }
-                    }
-                }
-            }
-        }
-    },
+    "paths": {},
     "definitions": {
         "User": {
             "type": "object",
@@ -47,9 +22,6 @@
                             "type": "string"
                         },
                         "name": {
-                            "type": "string"
-                        },
-                        "email": {
                             "type": "string"
                         }
                     }

--- a/tests/data/v2.0/test_requires_and_allof/userapi.json
+++ b/tests/data/v2.0/test_requires_and_allof/userapi.json
@@ -1,0 +1,68 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "test"
+    },
+    "paths": {
+        "/users/{id}": {
+            "get": {
+                "consumes": [],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/User"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "User": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "allOf": [
+                {
+                    "$ref": "#/definitions/CommonBaseType"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "email": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        },
+        "CommonBaseType": {
+            "type": "object",
+            "properties": {
+                "commonBaseThing": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -97,6 +97,22 @@ def test_fails_on_invalid_external_ref_in_list():
     assert "is not valid under any of the given schemas" in str(excinfo.value)
 
 
+def test_requires_and_allof():
+    # The User definition in userapi.json is valid.
+    # This asserts that the requirements are correctly checked when the
+    # properties are nested under the "allOf" element.
+    my_dir = os.path.abspath(os.path.dirname(__file__))
+
+    userapi_path = os.path.join(
+        my_dir,
+        '../data/v2.0/test_requires_and_allof/userapi.json')
+
+    with open(userapi_path) as f:
+        userapi_spec = json.load(f)
+
+    validate_spec(userapi_spec)
+
+
 @pytest.fixture
 def node_spec():
     """Used in tests that have recursive $refs


### PR DESCRIPTION
Fixes an issue where `SwaggerValidationError` is raised if a definition has any `required` properties listed but has its `properties` nested under an `allOf`.