### PR TITLE
Rename to swagger-spec-validator to fix PyPI upload issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+2.0.4 (2017-03-10)
+------------------
+- Rename package to swagger-spec-validator to fix PyPI upload issues - #59
+
 2.0.3 (2016-11-23)
 ------------------
 - Ignore x- vendor extensions in the schema at the #/paths/{path}/{http_method} level - PR #45

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst
+include README.md
 # Required by python 2.6 even though we include these in our setup.py
 include swagger_spec_validator/schemas/v1.2/*
 include swagger_spec_validator/schemas/v2.0/*

--- a/swagger_spec_validator/__about__.py
+++ b/swagger_spec_validator/__about__.py
@@ -3,11 +3,11 @@ __all__ = [
     "__email__", "__license__"
 ]
 
-__title__ = "swagger_spec_validator"
+__title__ = "swagger-spec-validator"
 __summary__ = "Validation of Swagger specifications"
 __uri__ = "http://github.com/Yelp/swagger_spec_validator"
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 __author__ = "John Billings"
 __email__ = "billings@yelp.com"


### PR DESCRIPTION
This hopefully enables me to upload a new version to PyPI. It also fixes a wrong reference in MANIFEST.in.

Fixes #59.