### PR TITLE
Validate swagger specs with discriminator

### DIFF
--- a/tests/data/v2.0/test_polymorphic_specs/swagger.json
+++ b/tests/data/v2.0/test_polymorphic_specs/swagger.json
@@ -1,0 +1,130 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Small example of polymorphic Swaggr specs",
+    "version": "0.0.0",
+    "title": "Pets"
+  },
+  "basePath": "/",
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "Get all the pets",
+        "operationId": "get_pets",
+        "responses": {
+          "200": {
+            "description": "Pet List"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "BaseObject": {
+      "allOf": [
+        {"$ref": "#/definitions/GenericPet"}
+      ]
+    },
+    "GenericPet": {
+      "type": "object",
+      "title": "GenericPet",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "weight": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "type",
+        "weight"
+      ]
+    },
+    "Dog": {
+      "type": "object",
+      "title": "Dog",
+      "allOf": [
+        {
+          "$ref": "#/definitions/GenericPet"
+        },
+        {
+          "properties": {
+            "birth_date": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          "required": [
+            "birth_date"
+          ]
+        }
+      ]
+    },
+    "Cat": {
+      "type": "object",
+      "title": "Cat",
+      "allOf": [
+        {
+          "$ref": "#/definitions/GenericPet"
+        },
+        {
+          "properties": {
+            "color": {
+              "type": "string",
+              "enum": [
+                "red",
+                "green",
+                "yellow",
+                "white",
+                "black"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Bird": {
+      "type": "object",
+      "title": "Bird",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Whale": {
+      "type": "object",
+      "title": "Whale",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Bird"
+        },
+        {
+          "properties": {
+            "weight": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "PetList": {
+      "type": "object",
+      "properties": {
+        "number_of_pets": {
+          "type": "integer"
+        },
+        "list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GenericPet"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/data/v2.0/test_polymorphic_specs/swagger.json
+++ b/tests/data/v2.0/test_polymorphic_specs/swagger.json
@@ -28,6 +28,7 @@
     "GenericPet": {
       "type": "object",
       "title": "GenericPet",
+      "discriminator": "type",
       "properties": {
         "name": {
           "type": "string"

--- a/tests/validator20/conftest.py
+++ b/tests/validator20/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+from six.moves.urllib import parse as urlparse
 
 import pytest
 
@@ -22,3 +23,10 @@ def no_op_deref():
     the actual test.
     """
     return lambda x: x
+
+
+def get_spec_json_and_url(rel_url):
+    my_dir = os.path.abspath(os.path.dirname(__file__))
+    abs_path = os.path.realpath(os.path.join(my_dir, rel_url))
+    with open(abs_path) as f:
+        return json.loads(f.read()), urlparse.urljoin('file:', abs_path)

--- a/tests/validator20/conftest.py
+++ b/tests/validator20/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -8,6 +9,11 @@ def petstore_contents():
     my_dir = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(my_dir, '../data/v2.0/petstore.json')) as f:
         return f.read()
+
+
+@pytest.fixture
+def petstore_dict(petstore_contents):
+    return json.loads(petstore_contents)
 
 
 @pytest.fixture

--- a/tests/validator20/get_collapsed_properties_map_test.py
+++ b/tests/validator20/get_collapsed_properties_map_test.py
@@ -1,0 +1,50 @@
+import functools
+from tests.validator20.conftest import get_spec_json_and_url
+from swagger_spec_validator.validator20 import validate_json, deref
+from swagger_spec_validator.validator20 import get_collapsed_properties_type_mapping
+
+
+def get_deref(spec_dict):
+    swagger_resolver = validate_json(
+        spec_dict,
+        'schemas/v2.0/schema.json',
+    )
+    return functools.partial(deref, resolver=swagger_resolver)
+
+
+def test_get_collapsed_properties_type_mapping_simple_case():
+    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    swagger_dict, _ = get_spec_json_and_url(file_path)
+
+    swagger_dict['definitions']['GenericPet']['discriminator'] = 'type'
+
+    required_parameters, not_required_parameters = get_collapsed_properties_type_mapping(
+        definition=swagger_dict['definitions']['GenericPet'],
+        deref=get_deref(swagger_dict),
+    )
+    assert required_parameters == {'type': 'string', 'weight': 'integer'}
+    assert not_required_parameters == {'name': 'string'}
+
+
+def test_get_collapsed_properties_type_mapping_allOf_add_required_property():
+    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    swagger_dict, _ = get_spec_json_and_url(file_path)
+
+    required_parameters, not_required_parameters = get_collapsed_properties_type_mapping(
+        definition=swagger_dict['definitions']['Dog'],
+        deref=get_deref(swagger_dict),
+    )
+    assert required_parameters == {'type': 'string', 'weight': 'integer', 'birth_date': 'string'}
+    assert not_required_parameters == {'name': 'string'}
+
+
+def test_get_collapsed_properties_type_mapping_allOf_add_not_required_property():
+    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    swagger_dict, _ = get_spec_json_and_url(file_path)
+
+    required_parameters, not_required_parameters = get_collapsed_properties_type_mapping(
+        definition=swagger_dict['definitions']['Cat'],
+        deref=get_deref(swagger_dict),
+    )
+    assert required_parameters == {'type': 'string', 'weight': 'integer'}
+    assert not_required_parameters == {'name': 'string', 'color': 'string'}

--- a/tests/validator20/get_collapsed_properties_map_test.py
+++ b/tests/validator20/get_collapsed_properties_map_test.py
@@ -1,7 +1,7 @@
 import functools
 from tests.validator20.conftest import get_spec_json_and_url
 from swagger_spec_validator.validator20 import validate_json, deref
-from swagger_spec_validator.validator20 import get_collapsed_properties_type_mapping
+from swagger_spec_validator.validator20 import get_collapsed_properties_type_mappings
 
 
 def get_deref(spec_dict):
@@ -16,9 +16,7 @@ def test_get_collapsed_properties_type_mapping_simple_case():
     file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
-    swagger_dict['definitions']['GenericPet']['discriminator'] = 'type'
-
-    required_parameters, not_required_parameters = get_collapsed_properties_type_mapping(
+    required_parameters, not_required_parameters = get_collapsed_properties_type_mappings(
         definition=swagger_dict['definitions']['GenericPet'],
         deref=get_deref(swagger_dict),
     )
@@ -30,7 +28,7 @@ def test_get_collapsed_properties_type_mapping_allOf_add_required_property():
     file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
-    required_parameters, not_required_parameters = get_collapsed_properties_type_mapping(
+    required_parameters, not_required_parameters = get_collapsed_properties_type_mappings(
         definition=swagger_dict['definitions']['Dog'],
         deref=get_deref(swagger_dict),
     )
@@ -42,7 +40,7 @@ def test_get_collapsed_properties_type_mapping_allOf_add_not_required_property()
     file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
-    required_parameters, not_required_parameters = get_collapsed_properties_type_mapping(
+    required_parameters, not_required_parameters = get_collapsed_properties_type_mappings(
         definition=swagger_dict['definitions']['Cat'],
         deref=get_deref(swagger_dict),
     )

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -9,6 +9,14 @@ from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator20 import validate_spec
 
 
+def get_spec_json_and_url(rel_url):
+    my_dir = os.path.abspath(os.path.dirname(__file__))
+    abs_path = os.path.realpath(os.path.join(my_dir, rel_url))
+    with open(abs_path) as f:
+        return json.loads(f.read()), urlparse.urljoin('file:', abs_path)
+
+
+
 @pytest.fixture
 def minimal_swagger_dict():
     """Return minimal dict that respresents a swagger spec - useful as a base
@@ -27,9 +35,8 @@ def minimal_swagger_dict():
     }
 
 
-def test_success(petstore_contents):
-    assert isinstance(validate_spec(json.loads(petstore_contents)),
-                      RefResolver)
+def test_success(petstore_dict):
+    assert isinstance(validate_spec(petstore_dict), RefResolver)
 
 
 def test_definitons_not_present_success(minimal_swagger_dict):
@@ -50,25 +57,20 @@ def test_api_parameters_as_refs():
     #          -> instagram.yaml
     #
     # and then export it to a json file.
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(my_dir, '../data/v2.0/instagram.json')) as f:
-        validate_spec(json.loads(f.read()))
+    instagram_specs, _ = get_spec_json_and_url(
+        '../data/v2.0/instagram.json'
+    )
+    validate_spec(instagram_specs)
 
 
 def test_fails_on_invalid_external_ref_in_dict():
     # The external ref in petstore.json is valid.
     # The contents of the external ref (pet.json#/getall) is not - the 'name'
     # key in the parameter is missing.
-    my_dir = os.path.abspath(os.path.dirname(__file__))
 
-    petstore_path = os.path.join(
-        my_dir,
-        '../data/v2.0/test_fails_on_invalid_external_ref/petstore.json')
-
-    with open(petstore_path) as f:
-        petstore_spec = json.load(f)
-
-    petstore_url = 'file://{0}'.format(petstore_path)
+    petstore_spec, petstore_url = get_spec_json_and_url(
+        '../data/v2.0/test_fails_on_invalid_external_ref/petstore.json'
+    )
 
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec(petstore_spec, petstore_url)
@@ -82,14 +84,9 @@ def test_fails_on_invalid_external_ref_in_list():
     # - the 'name' key in the parameter is missing.
     my_dir = os.path.abspath(os.path.dirname(__file__))
 
-    petstore_path = os.path.join(
-        my_dir,
-        '../data/v2.0/test_fails_on_invalid_external_ref_in_list/petstore.json')
-
-    with open(petstore_path) as f:
-        petstore_spec = json.load(f)
-
-    petstore_url = 'file://{0}'.format(petstore_path)
+    petstore_spec, petstore_url = get_spec_json_and_url(
+        '../data/v2.0/test_fails_on_invalid_external_ref_in_list/petstore.json'
+    )
 
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec(petstore_spec, petstore_url)
@@ -131,11 +128,6 @@ def test_recursive_ref_failure(minimal_swagger_dict, node_spec):
 
 def test_complicated_refs():
 
-    def get_spec_json_and_url(rel_url):
-        my_dir = os.path.abspath(os.path.dirname(__file__))
-        abs_path = os.path.join(my_dir, rel_url)
-        with open(abs_path) as f:
-            return json.loads(f.read()), urlparse.urljoin('file:', abs_path)
 
     # Split the swagger spec into a bunch of different json files and use
     # $refs all over to place to wire stuff together - see the test-data

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -135,8 +135,6 @@ def test_specs_with_discriminator():
     file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
-    swagger_dict['definitions']['GenericPet']['discriminator'] = 'type'
-
     validate_spec(swagger_dict)
 
 
@@ -176,8 +174,6 @@ def test_specs_with_discriminator_fail_because_not_in_properties():
 def test_specs_with_discriminator_in_allOf():
     file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
-
-    swagger_dict['definitions']['BaseObject']['discriminator'] = 'type'
 
     validate_spec(swagger_dict)
 


### PR DESCRIPTION
[bravado-core pull #159](https://github.com/Yelp/bravado-core/pull/159) added handling of polymorphic object (via discriminator field) for model unmarshalling and object validation.
This PR is targeting the validation of the ``discriminator`` on Swagger Specs level.
The validation takes care of ``discriminator`` attribute should:
* be ``required``
* targeting a ``string`` attribute

During the execution of this PR I have also:
* refactored a bit the tests to reduce boilerplate code
* added ``get_collapsed_properties_type_mapping`` for getting all the the defined fields with related types splitting them between required fields and not required fields

@sjaensch when you get around this you could validate the code?
If everything is fine I'll add a new line to the CHANGELOG and than we should eventually consider to release a new version
Thanks a lot!