### PR TITLE
validate_unresolvable_path_params: Make error message more helpful.

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -285,10 +285,10 @@ def validate_unresolvable_path_params(path_name, path_params):
 
     :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
     """
-    msg = "Path Parameter used is not defined"
+    msg = "Path Parameter used is not documented"
     for path in get_path_params_from_url(path_name):
         if path not in path_params:
-            raise SwaggerValidationError("%s: %s" % (msg, path))
+            raise SwaggerValidationError("%s: %s in %s" % (msg, path, path_name))
 
 
 def is_ref(spec_dict):


### PR DESCRIPTION
The validate_unresolvable_path_params error message is currently quite terse and it is not clear where the missing field is, and what is actually the problem it's trying to point out.