### PR TITLE
Flattern spec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'jsonschema',
+        'pyyaml',
         'six',
     ],
     license=about['__license__']

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+import sys
 from setuptools import find_packages, setup
 
 base_dir = os.path.dirname(__file__)
@@ -9,6 +10,15 @@ base_dir = os.path.dirname(__file__)
 about = {}
 with open(os.path.join(base_dir, "swagger_spec_validator", "__about__.py")) as f:
     exec(f.read(), about)
+
+
+has_enum = sys.version_info >= (3, 4)
+
+install_requires = [
+    'jsonschema',
+    'pyyaml',
+    'six',
+]
 
 setup(
     name=about['__title__'],
@@ -28,10 +38,6 @@ setup(
         ],
     },
     include_package_data=True,
-    install_requires=[
-        'jsonschema',
-        'pyyaml',
-        'six',
-    ],
-    license=about['__license__']
+    install_requires=install_requires if has_enum else (install_requires + ['enum34']),
+    license=about['__license__'],
 )

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -41,11 +41,12 @@ def read_file(file_path):
 def read_url(url):
     if urlparse(url).scheme == 'file':
         fp = urlopen(url)
+        # NOTE: JSON is a subset of YAML so it is safe to read JSON as it is YAML
         return safe_load(fp)
-    else:
-        with contextlib.closing(request.urlopen(url, timeout=TIMEOUT_SEC)) as fh:
-            # NOTE: JSON is a subset of YAML so it is safe to read JSON as it is YAML
-            return safe_load(fh.read().decode('utf-8'))
+
+    with contextlib.closing(request.urlopen(url, timeout=TIMEOUT_SEC)) as remote_request:
+        # NOTE: JSON is a subset of YAML so it is safe to read JSON as it is YAML
+        return safe_load(remote_request.fp)
 
 
 class SwaggerValidationError(Exception):

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -1,12 +1,14 @@
 import contextlib
 import sys
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
+from yaml import safe_load
+
+
 import six
 from six.moves.urllib import request
+from six.moves.urllib.parse import urlparse
+from jsonschema.compat import urlopen
+
 
 TIMEOUT_SEC = 1
 
@@ -23,9 +25,27 @@ def wrap_exception(method):
     return wrapper
 
 
-def load_json(url):
-    with contextlib.closing(request.urlopen(url, timeout=TIMEOUT_SEC)) as fh:
-        return json.loads(fh.read().decode('utf-8'))
+def read_file(file_path):
+    """
+    Utility method for reading a JSON/YAML file and converting it to a Python dictionary
+    :param file_path: path of the file to read
+
+    :return: Python dictionary representation of the JSON file
+    :rtype: dict
+    """
+    with open(file_path) as f:
+        # NOTE: JSON is a subset of YAML so it is safe to read JSON as it is YAML
+        return safe_load(f)
+
+
+def read_url(url):
+    if urlparse(url).scheme == 'file':
+        fp = urlopen(url)
+        return safe_load(fp)
+    else:
+        with contextlib.closing(request.urlopen(url, timeout=TIMEOUT_SEC)) as fh:
+            # NOTE: JSON is a subset of YAML so it is safe to read JSON as it is YAML
+            return safe_load(fh.read().decode('utf-8'))
 
 
 class SwaggerValidationError(Exception):

--- a/swagger_spec_validator/ref_validators.py
+++ b/swagger_spec_validator/ref_validators.py
@@ -6,8 +6,17 @@ import jsonschema
 from jsonschema.compat import iteritems
 from jsonschema.validators import Draft4Validator
 from jsonschema import validators, _validators
+from swagger_spec_validator import common
+
 
 log = logging.getLogger(__name__)
+
+
+default_handlers = {
+    'http': common.read_url,
+    'https': common.read_url,
+    'file': common.read_url,
+}
 
 
 def validate(instance, schema, instance_cls, cls=None, *args, **kwargs):
@@ -69,7 +78,8 @@ def create_dereffing_validator(instance_resolver):
             validator_wrapper,
             instance_resolver=instance_resolver,
             visited_refs=visited_refs,
-            default_validator_callable=v)
+            default_validator_callable=v,
+        )
 
     return validators.extend(Draft4Validator, bound_validators)
 
@@ -166,7 +176,7 @@ def attach_scope(ref_dict, instance_resolver):
     validations.
 
     :param ref_dict: dict with $ref key
-    :type instance_resolver: :class:`jsonschema.validators.RefResolver`
+    :type instance_resolver: :class:`jsonschema.RefResolver`
     """
     if 'x-scope' in ref_dict:
         log.debug('Ref %s already has scope attached' % ref_dict['$ref'])
@@ -181,7 +191,7 @@ def in_scope(resolver, ref_dict):
 
     The resolver's original scope is restored when exiting the context manager.
 
-    :type resolver: :class:`jsonschema.validators.RefResolver
+    :type resolver: :class:`jsonschema.RefResolver
     :type ref_dict: dict
     """
     if 'x-scope' not in ref_dict:

--- a/swagger_spec_validator/schemas/v2.0/object_mappings.json
+++ b/swagger_spec_validator/schemas/v2.0/object_mappings.json
@@ -1,0 +1,56 @@
+{
+    "API_KEY_SECURITY": {
+        "$ref": "schema.json#/definitions/apiKeySecurity"
+    },
+    "CONTACT": {
+        "$ref": "schema.json#/definitions/contact"
+    },
+    "DEFINITIONS": {
+        "$ref": "schema.json#/definitions/definitions"
+    },
+    "EXTERNAL_DOCS": {
+        "$ref": "schema.json#/definitions/externalDocs"
+    },
+    "INFO": {
+        "$ref": "schema.json#/definitions/info"
+    },
+    "LICENSE": {
+        "$ref": "schema.json#/definitions/license"
+    },
+    "OPERATION": {
+        "$ref": "schema.json#/definitions/operation"
+    },
+    "PARAMETER": {
+        "$ref": "schema.json#/definitions/parameter"
+    },
+    "PARAMETERS_LIST": {
+        "$ref": "schema.json#/definitions/parametersList"
+    },
+    "PARAMETER_DEFINITIONS": {
+        "$ref": "schema.json#/definitions/parameterDefinitions"
+    },
+    "PATHS": {
+        "$ref": "schema.json#/definitions/paths"
+    },
+    "PATH_ITEM": {
+        "$ref": "schema.json#/definitions/pathItem"
+    },
+    "RESPONSE": {
+        "$ref": "schema.json#/definitions/response"
+    },
+    "RESPONSES": {
+        "$ref": "schema.json#/definitions/responses"
+    },
+    "RESPONSE_VALUE": {
+        "$ref": "schema.json#/definitions/responseValue"
+    },
+    "SCHEMA": {
+        "$ref": "schema.json#/definitions/schema"
+    },
+    "SECURITY": {
+        "$ref": "schema.json#/definitions/security"
+    },
+    "TAG": {
+        "$ref": "schema.json#/definitions/tag"
+    }
+}

--- a/swagger_spec_validator/schemas/v2.0/object_mappings.json
+++ b/swagger_spec_validator/schemas/v2.0/object_mappings.json
@@ -8,6 +8,9 @@
     "DEFINITIONS": {
         "$ref": "schema.json#/definitions/definitions"
     },
+    "EXAMPLES": {
+        "$ref": "schema.json#/definitions/examples"
+    },
     "EXTERNAL_DOCS": {
         "$ref": "schema.json#/definitions/externalDocs"
     },

--- a/swagger_spec_validator/util.py
+++ b/swagger_spec_validator/util.py
@@ -1,8 +1,9 @@
 import logging
 
-from swagger_spec_validator import validator12, validator20
+from swagger_spec_validator import validator12
+from swagger_spec_validator import validator20
 from swagger_spec_validator.common import SwaggerValidationError
-from swagger_spec_validator.common import load_json
+from swagger_spec_validator.common import read_url
 from swagger_spec_validator.common import wrap_exception
 
 
@@ -48,6 +49,6 @@ def validate_spec_url(spec_url):
                        as `file://` this must be an absolute url for
                        cross-refs to work correctly.
     """
-    spec_json = load_json(spec_url)
+    spec_json = read_url(spec_url)
     validator = get_validator(spec_json, spec_url)
     validator.validate_spec(spec_json, spec_url)

--- a/swagger_spec_validator/util.py
+++ b/swagger_spec_validator/util.py
@@ -1,10 +1,19 @@
 import logging
 
+from enum import Enum
+from six import iteritems
+
+from jsonschema import RefResolver
+from jsonschema.exceptions import ValidationError
 from swagger_spec_validator import validator12
 from swagger_spec_validator import validator20
+from swagger_spec_validator import ref_validators
+from swagger_spec_validator.common import read_file
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.common import read_url
 from swagger_spec_validator.common import wrap_exception
+
+from pkg_resources import resource_filename
 
 
 log = logging.getLogger(__name__)
@@ -52,3 +61,92 @@ def validate_spec_url(spec_url):
     spec_json = read_url(spec_url)
     validator = get_validator(spec_json, spec_url)
     validator.validate_spec(spec_json, spec_url)
+
+
+def _initialize_Swagger2dot0ObjectType(object_mapping_schema_path='schemas/v2.0/object_mappings.json'):
+    """
+    Initialize Swagger2dot0ObjectType Enum from Object Mapping configurations.
+
+    :param object_mapping_schema_path: package relative path of the json schema file representing the object mappings.
+    :return: Swagger2dot0ObjectType enum
+    """
+    object_mappings_abspath = resource_filename('swagger_spec_validator', object_mapping_schema_path)
+
+    # Load object mappings from JSON config file
+    object_mappings = read_file(object_mappings_abspath)
+
+    object_mappings_resolver = RefResolver(
+        base_uri='file://{0}'.format(object_mappings_abspath),
+        referrer=object_mappings,
+    )
+    mappings = {}
+    for name, json_ref in iteritems(object_mappings):
+        _, schema = object_mappings_resolver.resolve(json_ref['$ref'])
+        mappings[name] = schema
+
+    return Enum('Swagger2dot0ObjectType', mappings)
+
+
+Swagger2dot0ObjectType = _initialize_Swagger2dot0ObjectType()
+
+
+def determine_swagger2dot0_object_type(object_dict, object_resolver=None, spec_url='', http_handlers=None, possible_types=None):
+    """
+    Determine the possible Swagger Object types for a given object dictionary representation.
+
+    :param object_dict: swagger spec json dict to determine the type
+    :type object_dict: dict
+    :param object_resolver: swagger spec reference resolver (ie. return value of ``swagger_spec_validator.validator20.validate_spec``)
+    :type  object_resolver: jsonschema.RefResolver
+    :param spec_url: url from which spec_dict was retrieved. Used for dereferencing refs. eg: file:///foo/swagger.json
+    :type spec_url: string
+    :param http_handlers: used to download any remote $refs in spec_dict with
+        a custom http client. Defaults to None in which case the default
+        http client built into jsonschema's RefResolver is used. This
+        is a mapping from uri scheme to a callable that takes a
+        uri.
+    :param possible_types: Swagger2dot0 types to iterate. If None is set all the possible types will be analyzed
+    :type possible_types: iterable[Swagger2dot0]
+
+    :return: Set of Swagger2dot0 types under which object_dict is valid
+    :rtype: set[Swagger2dot0]
+    """
+
+    def is_valid(object_type):
+        try:
+            validator_cls = ref_validators.create_dereffing_validator(object_resolver)
+            validator = validator_cls(
+                object_type.value,  # JSON Specification of self SwaggerObjectType
+                resolver=schema_resolver,
+            )
+            validator.validate(object_dict)
+            return True
+        except ValidationError:
+            return False
+
+    _schema_path = resource_filename('swagger_spec_validator', 'schemas/v2.0/schema.json')
+
+    # Init schema resolver
+    schema = read_file(_schema_path)
+    schema_resolver = RefResolver(
+        base_uri='file://{0}'.format(_schema_path),
+        referrer=schema,
+    )
+
+    if not object_resolver:
+        object_resolver = RefResolver(
+            base_uri=spec_url,
+            referrer=object_dict,
+            handlers=http_handlers or {},
+        )
+
+    if possible_types is None:
+        possible_types = set(Swagger2dot0ObjectType)
+    else:
+        possible_types = set(Swagger2dot0ObjectType).intersection(set(possible_types))
+
+    return {
+        swagger_object_type
+        for swagger_object_type in possible_types
+        if is_valid(object_type=swagger_object_type)
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+
+import pytest
+from six.moves.urllib.parse import urljoin
+
+
+@pytest.fixture
+def test_dir():
+    return os.path.abspath(os.path.dirname(__file__))
+
+
+def get_url(absolute_path):
+    return urljoin('file:', absolute_path)

--- a/tests/data/invalid_json_invalid_yaml
+++ b/tests/data/invalid_json_invalid_yaml
@@ -1,0 +1,2 @@
+# This file is a not valid JSON and YAML file
+{

--- a/tests/data/v2.0/minimal.yaml
+++ b/tests/data/v2.0/minimal.yaml
@@ -1,0 +1,12 @@
+# http://editor2.swagger.io/spec-files/minimal.yaml
+---
+swagger: '2.0'
+info:
+  version: 0.0.0
+  title: Simple API
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/tests/data/v2.0/test_complicated_refs/definitions/pet.yaml
+++ b/tests/data/v2.0/test_complicated_refs/definitions/pet.yaml
@@ -1,0 +1,4 @@
+type: object
+properties:
+  name:
+    type: string

--- a/tests/data/v2.0/test_complicated_refs/swagger.json
+++ b/tests/data/v2.0/test_complicated_refs/swagger.json
@@ -16,6 +16,9 @@
     }
   },
   "definitions": {
+      "pet": {
+          "$ref": "definitions/pet.yaml"
+      },
       "pong": {
           "$ref": "definitions/definitions.json#/pong"
       }

--- a/tests/util/SwaggerObjectType_test.py
+++ b/tests/util/SwaggerObjectType_test.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+import mock
+from jsonschema import RefResolver, Draft4Validator
+
+from swagger_spec_validator.common import read_file
+from swagger_spec_validator.util import _initialize_Swagger2dot0ObjectType
+from pkg_resources import resource_filename
+
+
+def _reinitialize_Swagger2dot0ObjectType():
+    # This is needed to re-initialize SwaggerObject with different files
+    global Swagger2dot0ObjectType
+    Swagger2dot0ObjectType = _initialize_Swagger2dot0ObjectType()
+
+
+@mock.patch('swagger_spec_validator.util.read_file')
+def test_SwaggerObjectType_with_no_mappings(mock_read_file):
+    mock_read_file.return_value = {}
+    _reinitialize_Swagger2dot0ObjectType()
+
+    assert list(Swagger2dot0ObjectType) == []
+
+
+def test_ensure_that_object_mappings_file_is_valid():
+    _reinitialize_Swagger2dot0ObjectType()
+    _object_mappings_path = resource_filename('swagger_spec_validator', 'schemas/v2.0/object_mappings.json')
+
+    # Ensure that object_mappings file is valid
+    Draft4Validator(schema={
+        'additionalProperties': {
+            'type': 'object',
+            'required': [
+                '$ref'
+            ],
+            'additionalProperties': False,
+            'properties': {
+                '$ref': {
+                    'type': 'string',
+                },
+            },
+        },
+        'minProperties': 1,
+    }).validate(read_file(_object_mappings_path))
+    assert len(list(Swagger2dot0ObjectType)) >= 1
+
+
+@mock.patch.object(RefResolver, 'resolve')
+@mock.patch('swagger_spec_validator.util.read_file')
+def test_SwaggerObjectType_mocked_mapping(mock_read_file, mock_resolve):
+    reference_value = 'schema.json#/definitions/'
+    dereferenced_schema = 'DEREFERENCED OBJECT'
+    mock_read_file.return_value = {
+        'KEY': {
+            '$ref': reference_value,
+        },
+    }
+    mock_resolve.return_value = 'URI', dereferenced_schema
+    _reinitialize_Swagger2dot0ObjectType()
+
+    assert Swagger2dot0ObjectType.KEY.name == 'KEY'
+    assert Swagger2dot0ObjectType.KEY.value == dereferenced_schema
+
+    mock_resolve.assert_called_once_with(reference_value)

--- a/tests/util/common_test.py
+++ b/tests/util/common_test.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+import os
+import yaml
+
+import mock
+import pytest
+import httpretty
+
+from swagger_spec_validator.common import read_file
+from swagger_spec_validator.common import read_url
+from tests.conftest import get_url
+
+
+@pytest.mark.parametrize(
+    'file_path',
+    [
+        'data/v2.0/petstore.json',
+        'data/v2.0/minimal.yaml',
+    ]
+)
+@mock.patch('swagger_spec_validator.common.safe_load')
+def test_read_file_valid(mock_safe_load, test_dir, file_path):
+    abs_file_path = os.path.join(test_dir, file_path)
+    f = read_file(abs_file_path)
+
+    assert mock_safe_load.called
+    assert f == mock_safe_load.return_value
+
+
+def test_read_file_invalid(test_dir):
+    abs_file_path = os.path.join(test_dir, 'data/invalid_json_invalid_yaml')
+
+    with pytest.raises(yaml.parser.ParserError):
+        read_file(abs_file_path)
+
+
+@pytest.mark.parametrize(
+    'file_path',
+    [
+        'data/v2.0/petstore.json',
+        'data/v2.0/minimal.yaml',
+    ]
+)
+@mock.patch('swagger_spec_validator.common.safe_load')
+def test_read_url_reads_local_file(mock_safe_load, test_dir, file_path):
+    abs_file_path = os.path.join(test_dir, file_path)
+    url = get_url(abs_file_path)
+    f = read_url(url)
+
+    assert mock_safe_load.called
+    assert f == mock_safe_load.return_value
+
+
+@httpretty.activate
+@pytest.mark.parametrize(
+    'url, file_path',
+    [
+        ('http://service.my/swagger.json', 'data/v2.0/petstore.json'),
+        ('http://service.my/swagger.yaml', 'data/v2.0/minimal.yaml'),
+        ('http://service.my/swagger.txt', 'data/v2.0/petstore.json'),
+    ]
+)
+@mock.patch('swagger_spec_validator.common.safe_load')
+def test_read_url_reads_remote(mock_safe_load, test_dir, url, file_path):
+    abs_file_path = os.path.join(test_dir, file_path)
+    with open(abs_file_path) as fp:
+        file_content = fp.read()
+
+    content_type_mapping = {
+        '.txt': 'text/plain',
+        '.json': 'application/json',
+        '.yaml': 'application/yaml',
+    }
+
+    httpretty.register_uri(
+        httpretty.GET, url,
+        body=file_content,
+        content_type=content_type_mapping[os.path.splitext(file_path)[1]],
+    )
+
+    f = read_url(url)
+
+    assert mock_safe_load.called
+    assert f == mock_safe_load.return_value

--- a/tests/util/determine_object_type_test.py
+++ b/tests/util/determine_object_type_test.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from swagger_spec_validator.util import determine_swagger2dot0_object_type
 from swagger_spec_validator.util import Swagger2dot0ObjectType
 
@@ -40,4 +42,25 @@ def test_determine_object_type_with_no_type_hint():
                 }
             }
         },
-    ) == {Swagger2dot0ObjectType.PATH_ITEM}
+        greedy_detection=False,
+    ) == {Swagger2dot0ObjectType.EXAMPLES, Swagger2dot0ObjectType.PATH_ITEM}
+
+
+@pytest.mark.parametrize(
+    'greedy_detection', (True, False),
+)
+def test_SwaggerObjectType_with_no_mappings(greedy_detection):
+    matched_types = determine_swagger2dot0_object_type(
+        object_dict={
+            'name': 'pung',
+            'in': 'query',
+            'description': 'true or false',
+            'type': 'boolean',
+        },
+        possible_types=[Swagger2dot0ObjectType.PARAMETER, Swagger2dot0ObjectType.EXAMPLES],
+        greedy_detection=greedy_detection,
+    )
+    if greedy_detection:
+        assert matched_types == {Swagger2dot0ObjectType.PARAMETER}
+    else:
+        assert matched_types == {Swagger2dot0ObjectType.PARAMETER, Swagger2dot0ObjectType.EXAMPLES}

--- a/tests/util/determine_object_type_test.py
+++ b/tests/util/determine_object_type_test.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from swagger_spec_validator.util import determine_swagger2dot0_object_type
+from swagger_spec_validator.util import Swagger2dot0ObjectType
+
+
+def test_determine_object_type_schema_succeed():
+    assert determine_swagger2dot0_object_type(
+        object_dict={'type': 'object'},
+        possible_types=[Swagger2dot0ObjectType.SCHEMA],
+    ) == {Swagger2dot0ObjectType.SCHEMA}
+
+
+def test_determine_object_type_parameter_fail():
+    assert determine_swagger2dot0_object_type(
+        object_dict={'type': 'object'},
+        possible_types=[Swagger2dot0ObjectType.PARAMETER],
+    ) == set()
+
+
+def test_determine_object_type_with_multiple_type_hints():
+    assert determine_swagger2dot0_object_type(
+        object_dict={
+            'name': 'pung',
+            'in': 'query',
+            'description': 'true or false',
+            'type': 'boolean',
+        },
+        possible_types=[Swagger2dot0ObjectType.PARAMETER, Swagger2dot0ObjectType.SCHEMA],
+    ) == {Swagger2dot0ObjectType.PARAMETER}
+
+
+def test_determine_object_type_with_no_type_hint():
+    assert determine_swagger2dot0_object_type(
+        object_dict={
+            'get': {
+                'responses': {
+                    '200': {
+                        'description': 'HTTP 200/OK',
+                    }
+                }
+            }
+        },
+    ) == {Swagger2dot0ObjectType.PATH_ITEM}

--- a/tests/util/validate_spec_url_test.py
+++ b/tests/util/validate_spec_url_test.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from swagger_spec_validator.common import SwaggerValidationError
@@ -7,5 +8,14 @@ from swagger_spec_validator.util import validate_spec_url
 def test_raise_SwaggerValidationError_on_urlopen_error():
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec_url('http://foo')
-    assert ('<urlopen error [Errno -2] Name or service not known>'
-            in str(excinfo.value))
+    assert '<urlopen error [Errno -2] Name or service not known>' in str(excinfo.value) or \
+           '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(excinfo.value)
+
+
+@mock.patch('swagger_spec_validator.util.read_url')
+@mock.patch('swagger_spec_validator.util.get_validator')
+def test_validate_spec_url_success(mock_get_validator, mock_read_url):
+    spec_url = mock.Mock()
+    validate_spec_url(spec_url)
+    mock_read_url.assert_called_once_with(spec_url)
+    mock_get_validator.assert_called_once_with(mock_read_url.return_value, spec_url)

--- a/tests/validator12/run_test.py
+++ b/tests/validator12/run_test.py
@@ -5,6 +5,7 @@ import os
 import os.path
 
 import jsonschema.exceptions
+import pytest
 
 from swagger_spec_validator.validator12 import validate_api_declaration
 from swagger_spec_validator.validator12 import validate_resource_listing
@@ -27,23 +28,17 @@ def run_json_tests_with_func(json_test_paths, func):
         if test_name.endswith('_pass.json'):
             func(test_data)
         elif test_name.endswith('_fail.json'):
-            try:
+            with pytest.raises((SwaggerValidationError, jsonschema.exceptions.ValidationError)):
                 func(test_data)
-            except (SwaggerValidationError, jsonschema.exceptions.ValidationError):
-                pass
-            else:
-                raise ValueError('Validation error did not occur')
-        else:
-            raise ValueError('Invalid test name')
 
 
 def test_main():
     my_dir = os.path.abspath(os.path.dirname(__file__))
 
     run_json_tests_with_func(
-        glob.glob(os.path.join(my_dir, 'data/v1.2/api_declarations/*.json')),
+        glob.glob(os.path.join(my_dir, '../data/v1.2/api_declarations/*.json')),
         validate_api_declaration)
 
     run_json_tests_with_func(
-        glob.glob(os.path.join(my_dir, 'data/v1.2/resource_listings/*.json')),
+        glob.glob(os.path.join(my_dir, '../data/v1.2/resource_listings/*.json')),
         validate_resource_listing)

--- a/tests/validator12/validate_spec_test.py
+++ b/tests/validator12/validate_spec_test.py
@@ -24,11 +24,12 @@ def get_resource_listing():
 def test_http_success():
     mock_responses = make_mock_responses([API_DECLARATION_FILE])
 
-    with mock.patch('swagger_spec_validator.validator12.load_json',
-                    side_effect=mock_responses) as mock_load_json:
+    with mock.patch(
+        'swagger_spec_validator.validator12.read_url',
+        side_effect=mock_responses
+    ) as mock_read_url:
         validate_spec(get_resource_listing(), 'http://localhost/api-docs')
-
-        mock_load_json.assert_called_once_with('http://localhost/api-docs/foo')
+        mock_read_url.assert_called_once_with('http://localhost/api-docs/foo')
 
 
 def test_file_uri_success():

--- a/tests/validator12/validate_spec_url_test.py
+++ b/tests/validator12/validate_spec_url_test.py
@@ -25,11 +25,13 @@ def test_http_success():
     mock_responses = make_mock_responses([RESOURCE_LISTING_FILE,
                                           API_DECLARATION_FILE])
 
-    with mock.patch('swagger_spec_validator.validator12.load_json',
-                    side_effect=mock_responses) as mock_load_json:
+    with mock.patch(
+        'swagger_spec_validator.validator12.read_url',
+        side_effect=mock_responses,
+    ) as mock_read_url:
         validate_spec_url('http://localhost/api-docs')
 
-        mock_load_json.assert_has_calls([
+        mock_read_url.assert_has_calls([
             mock.call('http://localhost/api-docs'),
             mock.call('http://localhost/api-docs/foo'),
         ])

--- a/tests/validator12/validate_spec_url_test.py
+++ b/tests/validator12/validate_spec_url_test.py
@@ -49,5 +49,5 @@ def test_file_uri_success():
 def test_raise_SwaggerValidationError_on_urlopen_error():
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec_url('http://foo')
-    assert ('<urlopen error [Errno -2] Name or service not known>'
-            in str(excinfo.value))
+    assert '<urlopen error [Errno -2] Name or service not known>' in str(excinfo.value) or \
+           '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(excinfo.value)

--- a/tests/validator20/conftest.py
+++ b/tests/validator20/conftest.py
@@ -21,4 +21,4 @@ def get_spec_json_and_url(rel_url):
     my_dir = os.path.abspath(os.path.dirname(__file__))
     abs_path = os.path.realpath(os.path.join(my_dir, rel_url))
     with open(abs_path) as f:
-        return json.loads(f.read()), urlparse.urljoin('file:', abs_path)
+        return json.load(f), urlparse.urljoin('file:', abs_path)

--- a/tests/validator20/conftest.py
+++ b/tests/validator20/conftest.py
@@ -17,14 +17,6 @@ def petstore_dict(petstore_contents):
     return json.loads(petstore_contents)
 
 
-@pytest.fixture
-def no_op_deref():
-    """For functions that require a 'deref' callable but don't use $refs in
-    the actual test.
-    """
-    return lambda x: x
-
-
 def get_spec_json_and_url(rel_url):
     my_dir = os.path.abspath(os.path.dirname(__file__))
     abs_path = os.path.realpath(os.path.join(my_dir, rel_url))

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -126,9 +126,10 @@ def test_complicated_refs():
     #   resolver's store:
     #
     #   6 json files from ../../tests/data/v2.0/tests_complicated_refs/*
+    #   1 yaml files from ../../tests/data/v2.0/tests_complicated_refs/*
     #   1 draft3 spec
     #   1 draft4 spec
-    assert len(resolver.store) == 8
+    assert len(resolver.store) == 9
 
 
 def test_specs_with_discriminator():
@@ -201,6 +202,17 @@ def test_specs_with_discriminator_in_allOf_fail_because_not_string():
 
 
 def test_specs_with_discriminator_in_allOf_fail_because_not_in_properties():
+    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    swagger_dict, _ = get_spec_json_and_url(file_path)
+
+    swagger_dict['definitions']['BaseObject']['discriminator'] = 'an_other_property'
+
+    with pytest.raises(SwaggerValidationError) as excinfo:
+        validate_spec(swagger_dict)
+    assert 'discriminator (an_other_property) must be defined in properties' in str(excinfo.value)
+
+
+def test_read_yaml_specs():
     file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 

--- a/tests/validator20/validate_spec_url_test.py
+++ b/tests/validator20/validate_spec_url_test.py
@@ -33,6 +33,5 @@ def test_success_crossref_url_json():
 def test_raise_SwaggerValidationError_on_urlopen_error():
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec_url('http://foo')
-    assert ('<urlopen error [Errno -2] Name or service not known>'
-            in str(excinfo.value))
-
+    assert '<urlopen error [Errno -2] Name or service not known>' in str(excinfo.value) or \
+           '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(excinfo.value)

--- a/tests/validator20/validate_spec_url_test.py
+++ b/tests/validator20/validate_spec_url_test.py
@@ -9,13 +9,21 @@ from swagger_spec_validator.validator20 import validate_spec_url
 
 def test_success(petstore_contents):
     with mock.patch(
-            'swagger_spec_validator.validator20.load_json',
-            return_value=json.loads(petstore_contents)) as mock_load_json:
+            'swagger_spec_validator.validator20.read_url',
+            return_value=json.loads(petstore_contents),
+    ) as mock_read_url:
         validate_spec_url('http://localhost/api-docs')
-        mock_load_json.assert_called_once_with('http://localhost/api-docs')
+        mock_read_url.assert_called_once_with('http://localhost/api-docs')
 
 
-def test_success_crossref_url():
+def test_success_crossref_url_yaml():
+    my_dir = os.path.abspath(os.path.dirname(__file__))
+    urlpath = "file://{0}".format(os.path.join(
+        my_dir, "../data/v2.0/minimal.yaml"))
+    validate_spec_url(urlpath)
+
+
+def test_success_crossref_url_json():
     my_dir = os.path.abspath(os.path.dirname(__file__))
     urlpath = "file://{0}".format(os.path.join(
         my_dir, "../data/v2.0/relative_ref.json"))
@@ -27,3 +35,4 @@ def test_raise_SwaggerValidationError_on_urlopen_error():
         validate_spec_url('http://foo')
     assert ('<urlopen error [Errno -2] Name or service not known>'
             in str(excinfo.value))
+

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     flake8
     mock<1.1.0
     pytest
+    httpretty
 commands =
     py.test {posargs:tests}
     flake8 .

--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,8 @@ deps = {[testenv]deps}
 deps = {[testenv]deps}
     coverage
 commands =
-    coverage erase
-    coverage run --source=swagger_spec_validator --omit=swagger_spec_validator/__about__.py -m py.test {posargs:tests}
-    coverage combine
-    coverage report -m
+    coverage run --source=swagger_spec_validator/ --omit=swagger_spec_validator/__about__.py -m pytest --capture=no --strict {posargs:tests/}
+    coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
What is added
==========
 * YAML support within swagger_spec_validator
 * Swagger spec flattering (the main logic is extracted and enhanced from [pyramid_swagger](https://github.com/striglia/pyramid_swagger/blob/62c445b1f1eda489c72300417c7319cbdba1b95c/pyramid_swagger/api.py#L506))

Rationale
---------
Currently swagger spec flattering is provided by code present in [pyramid_swagger](https://github.com/striglia).
Personally I believe that this type of feature should be provided by a library that handles swagger specs and not by a library that handles an HTTP service swagger aware, it allows a better separation of concerns and allows user to update dependencies/libraries for the aspect that matters to him. 
Having this feature in a library that handles swagger specs allows also to remove/reduce heuristic code for object type determination (ie. [``pyramid_swagger.api.is_a_swagger_definition ``](https://github.com/striglia/pyramid_swagger/blob/master/pyramid_swagger/api.py#L308)) and allows to increase the usability of this feature on different libraries (like [bravado](https://github.com/Yelp/bravado) or [bravado-core](https://github.com/Yelp/bravado-core))

Commits explanation
---------------------
* **Add YAML Support**: adds ``common. read_url`` and ``common.read_file`` methods for reading JSON and YAML file from different sources
  *NOTE*: JSON is a subset of YAML, so reading a JSON file treating it as YAML is safe
  Code and Tests are extracted by #52 and #56, so a BIG thanks to @EvgeneOskin and @patrickw276
* **Make sure that test code has complete coverage**: improve ``validator12`` test coverage (some test code was not reachable); I added also assertion for ``urlopen error [Errno 8]`` because it is the error raised on OSX in case of opening an HTTP connection to an invalid URL
* **Add determine_object_type utility method**: defined ``Swagger2dot0ObjectType`` class that provide utility methods for determine the possible "type" of an object (ie. allows to determine if a given object could be a PathItem object).
  This utility will be useful during flattering, it avoid usage of heuristics for object type recognition.
 *NOTE*: The class is [JSON configured](https://github.com/Yelp/swagger_spec_validator/commit/3ee03e7b1412aa668a9cc9f068fea16456b54014#diff-dbb11ebfd26066be6535288220be8df8) to simplify future extensions without having direct impact on code.
* **Swagger 2.0 Spec flattering**: Injects the core logic for flattering swagger specs.
 *NOTE*: ``_marshal_uri`` and ``flattened_spec.descend`` methods are extracted and adapted from  [pyramid_swagger](https://github.com/striglia/pyramid_swagger/)
* **Swagger 2.0 Spec flattering: tests**: unit and integration tests for the new feature
 *NOTE*: I hope that I have tested the majority of the possible cases, if not please add a comment 😄 

