### PR TITLE
Centralize assertion on urlopen errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+def is_urlopen_error(exception):
+    return '<urlopen error [Errno -2] Name or service not known>' in str(exception) or \
+           '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(exception) or \
+           '<urlopen error [Errno -5] No address associated with hostname>' in str(exception)

--- a/tests/util/validate_spec_url_test.py
+++ b/tests/util/validate_spec_url_test.py
@@ -9,13 +9,13 @@ import pytest
 
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.util import validate_spec_url
+from tests.conftest import is_urlopen_error
 
 
 def test_raise_SwaggerValidationError_on_urlopen_error():
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec_url('http://foo')
-    assert '<urlopen error [Errno -2] Name or service not known>' in str(excinfo.value) or \
-           '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(excinfo.value)
+    assert is_urlopen_error(excinfo.value)
 
 
 @mock.patch('swagger_spec_validator.util.read_url')

--- a/tests/validator12/validate_spec_url_test.py
+++ b/tests/validator12/validate_spec_url_test.py
@@ -12,7 +12,7 @@ import pytest
 
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator12 import validate_spec_url
-
+from tests.conftest import is_urlopen_error
 
 RESOURCE_LISTING_FILE = os.path.abspath('tests/data/v1.2/foo/swagger_api.json')
 API_DECLARATION_FILE = os.path.abspath('tests/data/v1.2/foo/foo.json')
@@ -55,5 +55,4 @@ def test_file_uri_success():
 def test_raise_SwaggerValidationError_on_urlopen_error():
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec_url('http://foo')
-    assert '<urlopen error [Errno -2] Name or service not known>' in str(excinfo.value) or \
-           '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(excinfo.value)
+    assert is_urlopen_error(excinfo.value)

--- a/tests/validator20/validate_spec_url_test.py
+++ b/tests/validator20/validate_spec_url_test.py
@@ -12,6 +12,7 @@ import pytest
 
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator20 import validate_spec_url
+from tests.conftest import is_urlopen_error
 
 
 def test_success(petstore_contents):
@@ -40,5 +41,4 @@ def test_success_crossref_url_json():
 def test_raise_SwaggerValidationError_on_urlopen_error():
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec_url('http://foo')
-    assert '<urlopen error [Errno -2] Name or service not known>' in str(excinfo.value) or \
-           '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(excinfo.value)
+    assert is_urlopen_error(excinfo.value)


### PR DESCRIPTION
[Travis build](https://travis-ci.org/Yelp/swagger_spec_validator/builds/291579199) failed because a new error is raised in case of url open error.
The goal of this PR is to centralize the check of _is url open error_ into ``conftest.py``