### PR TITLE
Ensure that defaults are compliant with the object/parameter spec.

### DIFF
--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -8,9 +8,8 @@ import contextlib
 import sys
 
 import six
-from jsonschema.compat import urlopen
-from six.moves.urllib import request
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urljoin
+from six.moves.urllib.request import urlopen
 from yaml import safe_load
 
 
@@ -37,19 +36,13 @@ def read_file(file_path):
     :return: Python dictionary representation of the JSON file
     :rtype: dict
     """
-    with open(file_path) as f:
+    return read_url(urljoin('file://', file_path))
+
+
+def read_url(url, timeout=TIMEOUT_SEC):
+    with contextlib.closing(urlopen(url, timeout=timeout)) as fh:
         # NOTE: JSON is a subset of YAML so it is safe to read JSON as it is YAML
-        return safe_load(f)
-
-
-def read_url(url):
-    if urlparse(url).scheme == 'file':
-        fp = urlopen(url)
-        return safe_load(fp)
-    else:
-        with contextlib.closing(request.urlopen(url, timeout=TIMEOUT_SEC)) as fh:
-            # NOTE: JSON is a subset of YAML so it is safe to read JSON as it is YAML
-            return safe_load(fh.read().decode('utf-8'))
+        return safe_load(fh.read().decode('utf-8'))
 
 
 class SwaggerValidationError(Exception):

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -24,7 +24,7 @@ def wrap_exception(method):
         except Exception as e:
             six.reraise(
                 SwaggerValidationError,
-                SwaggerValidationError(str(e)),
+                SwaggerValidationError(str(e), e),
                 sys.exc_info()[2])
     return wrapper
 

--- a/swagger_spec_validator/ref_validators.py
+++ b/swagger_spec_validator/ref_validators.py
@@ -168,7 +168,7 @@ def deref_and_validate(validator, schema_element, instance, schema,
     if isinstance(instance, dict) and '$ref' in instance:
         ref = instance['$ref']
         if ref in visited_refs:
-            log.debug("Found cycle in %s" % ref)
+            log.debug("Found cycle in %s", ref)
             return
 
         # Annotate $ref dict with scope - used by custom validations
@@ -195,9 +195,9 @@ def attach_scope(ref_dict, instance_resolver):
     :type instance_resolver: :class:`jsonschema.RefResolver`
     """
     if 'x-scope' in ref_dict:
-        log.debug('Ref %s already has scope attached' % ref_dict['$ref'])
+        log.debug('Ref %s already has scope attached', ref_dict['$ref'])
         return
-    log.debug('Attaching x-scope to {}'.format(ref_dict))
+    log.debug('Attaching x-scope to %s', ref_dict)
     ref_dict['x-scope'] = list(instance_resolver._scopes_stack)
 
 

--- a/swagger_spec_validator/ref_validators.py
+++ b/swagger_spec_validator/ref_validators.py
@@ -13,6 +13,7 @@ from jsonschema import _validators
 from jsonschema import validators
 from jsonschema.compat import iteritems
 from jsonschema.validators import Draft4Validator
+from jsonschema.validators import RefResolver
 
 from swagger_spec_validator import common
 
@@ -90,6 +91,13 @@ def create_dereffing_validator(instance_resolver):
         )
 
     return validators.extend(Draft4Validator, bound_validators)
+
+
+def validate_schema_value(schema, value, swagger_resolver=None):
+    # pass resolver to avoid to refetch schema files
+    if swagger_resolver is None:
+        swagger_resolver = RefResolver.from_schema(schema)
+    create_dereffing_validator(swagger_resolver)(schema, resolver=swagger_resolver).validate(value)
 
 
 @contextlib.contextmanager

--- a/swagger_spec_validator/validator12.py
+++ b/swagger_spec_validator/validator12.py
@@ -78,7 +78,7 @@ def validate_spec_url(url):
     :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
     """
 
-    log.info('Validating %s' % url)
+    log.info('Validating %s', url)
     validate_spec(read_url(url), url)
 
 
@@ -100,7 +100,7 @@ def validate_spec(resource_listing, url):
 
     for api in resource_listing['apis']:
         path = get_resource_path(url, api['path'])
-        log.info('Validating %s' % path)
+        log.info('Validating %s', path)
         validate_api_declaration(read_url(path))
 
 

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -45,7 +45,7 @@ def deref(ref_dict, resolver):
     ref = ref_dict['$ref']
     with in_scope(resolver, ref_dict):
         with resolver.resolving(ref) as target:
-            log.debug('Resolving {}'.format(ref))
+            log.debug('Resolving %s', ref)
             return target
 
 
@@ -59,7 +59,7 @@ def validate_spec_url(spec_url):
     :rtype: :class:`jsonschema.RefResolver`
     :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
     """
-    log.info('Validating %s' % spec_url)
+    log.info('Validating %s', spec_url)
     return validate_spec(read_url(spec_url), spec_url)
 
 

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -12,6 +12,7 @@ from jsonschema.validators import Draft4Validator
 from jsonschema.validators import RefResolver
 from pkg_resources import resource_filename
 from six import iteritems
+from six import iterkeys
 
 from swagger_spec_validator import ref_validators
 from swagger_spec_validator.common import read_file
@@ -20,6 +21,7 @@ from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.common import wrap_exception
 from swagger_spec_validator.ref_validators import default_handlers
 from swagger_spec_validator.ref_validators import in_scope
+from swagger_spec_validator.ref_validators import validate_schema_value
 
 
 log = logging.getLogger(__name__)
@@ -141,6 +143,39 @@ def validate_json(spec_dict, schema_path, spec_url='', http_handlers=None):
     return spec_resolver
 
 
+@wrap_exception
+def validate_value_type(schema, value, deref):
+    # Extract resolver from deref partial build on ``validate_spec``
+    # This is used in order to use already fetched external references
+    # If it is missing a new RefResolver will be initialized
+    swagger_resolver = getattr(deref, 'keywords', {}).get('resolver', None)
+    validate_schema_value(schema=deref(schema), value=value, swagger_resolver=swagger_resolver)
+
+
+def validate_defaults_in_parameters(params_spec, deref):
+    """
+    Validates that default values for api parameters are
+    of the parameter type
+
+    :param params_spec: list of parameter objects (#/paths/<path>/<http_verb>/parameters)
+    :param deref: callable that dereferences $refs
+
+    :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
+    """
+    for param_spec in params_spec:
+        deref_param_spec = deref(param_spec)
+        if deref_param_spec.get('required', False):
+            # If the parameter is a required parameter, default has no meaning
+            continue
+
+        if 'default' in deref_param_spec:
+            validate_value_type(
+                schema=deref_param_spec,
+                value=deref_param_spec['default'],
+                deref=deref,
+            )
+
+
 def validate_apis(apis, deref):
     """Validates semantic errors in #/paths.
 
@@ -166,6 +201,7 @@ def validate_apis(apis, deref):
                 get_path_param_names(api_params, deref) +
                 get_path_param_names(oper_params, deref)))
             validate_unresolvable_path_params(api_name, all_path_params)
+            validate_defaults_in_parameters(oper_params, deref)
 
 
 def get_collapsed_properties_type_mappings(definition, deref):
@@ -200,6 +236,26 @@ def get_collapsed_properties_type_mappings(definition, deref):
     return required_properties, not_required_properties
 
 
+def validate_property_default(property_spec, deref):
+    """
+    Validates that default values for definitions are of the property type.
+    Enforces presence of "type" in case of "default" presence.
+
+    :param property_spec: schema object (#/definitions/<def_name>/properties/<property_name>
+    :param deref: callable that dereferences $refs
+
+    :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
+    """
+    deref_property_spec = deref(property_spec)
+    if 'default' in deref_property_spec:
+        validate_value_type(schema=property_spec, value=deref_property_spec['default'], deref=deref)
+
+
+def validate_defaults_in_definition(definition_spec, deref):
+    for property_name, property_spec in iteritems(definition_spec.get('properties', {})):
+        validate_property_default(property_spec, deref)
+
+
 def validate_definition(definition, deref, def_name=None):
     definition = deref(definition)
 
@@ -208,7 +264,7 @@ def validate_definition(definition, deref, def_name=None):
             validate_definition(inner_definition, deref)
     else:
         required = definition.get('required', [])
-        props = definition.get('properties', {}).keys()
+        props = iterkeys(definition.get('properties', {}))
         extra_props = list(set(required) - set(props))
         if extra_props:
             raise SwaggerValidationError(
@@ -216,6 +272,8 @@ def validate_definition(definition, deref, def_name=None):
                     extra_props
                 )
             )
+
+        validate_defaults_in_definition(definition, deref)
 
     if 'discriminator' in definition:
         required_props, not_required_props = get_collapsed_properties_type_mappings(definition, deref)


### PR DESCRIPTION
The goal of this PR is to fix #80 .

The main change introduced by this relates to ``validate_schema_value`` method that will allow checking that a property default is respecting the specification of the property itself.

Other changes introduced are:
 * let log library to handle formatting of messages (it will reduce the overhead of logging in case of logging level is not used)
 * Ensure that file pointers are closed after their use.