### PR TITLE
fixing the 'Definitions Object' validation.

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -194,7 +194,7 @@ def validate_definition(definition, deref, def_name=None):
     if 'allOf' in definition:
         for inner_definition in definition['allOf']:
             validate_definition(inner_definition, deref)
-    else:
+    elif isinstance(definition, dict):
         required = definition.get('required', [])
         props = definition.get('properties', {}).keys()
         extra_props = list(set(required) - set(props))


### PR DESCRIPTION
According to the specification 'These data types can be primitives, arrays or models'

See: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#definitionsObject


I would to see this fix on a 2.1.1 version, because I saw that the master already breaks the 2.x api.