### PR TITLE
Validation should fail if operation responses is composed by references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/build
 *.swp
 .cache/
 .idea/
+.pytest_cache/

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -176,7 +176,7 @@ def validate_defaults_in_parameters(params_spec, deref):
             )
 
 
-def validate_references_in_responses(api, http_verb, responses_dict):
+def validate_responses(api, http_verb, responses_dict):
     if is_ref(responses_dict):
         raise SwaggerValidationError(
             '{http_verb} {api} has not valid responses. Responses cannot be a reference to an other object.'.format(
@@ -212,7 +212,7 @@ def validate_apis(apis, deref):
                 get_path_param_names(oper_params, deref)))
             validate_unresolvable_path_params(api_name, all_path_params)
             validate_defaults_in_parameters(oper_params, deref)
-            validate_references_in_responses(api_name, oper_name, oper_body['responses'])
+            validate_responses(api_name, oper_name, oper_body['responses'])
 
 
 def get_collapsed_properties_type_mappings(definition, deref):

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -176,6 +176,16 @@ def validate_defaults_in_parameters(params_spec, deref):
             )
 
 
+def validate_references_in_responses(api, http_verb, responses_dict):
+    if is_ref(responses_dict):
+        raise SwaggerValidationError(
+            '{http_verb} {api} has not valid responses. Responses cannot be a reference to an other object.'.format(
+                http_verb=http_verb.upper(),
+                api=api,
+            )
+        )
+
+
 def validate_apis(apis, deref):
     """Validates semantic errors in #/paths.
 
@@ -202,6 +212,7 @@ def validate_apis(apis, deref):
                 get_path_param_names(oper_params, deref)))
             validate_unresolvable_path_params(api_name, all_path_params)
             validate_defaults_in_parameters(oper_params, deref)
+            validate_references_in_responses(api_name, oper_name, oper_body['responses'])
 
 
 def get_collapsed_properties_type_mappings(definition, deref):

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -179,7 +179,8 @@ def validate_defaults_in_parameters(params_spec, deref):
 def validate_responses(api, http_verb, responses_dict):
     if is_ref(responses_dict):
         raise SwaggerValidationError(
-            '{http_verb} {api} has not valid responses. Responses cannot be a reference to an other object.'.format(
+            '{http_verb} {api} does not have a valid responses section. '
+            'That section cannot be just a reference to another object.'.format(
                 http_verb=http_verb.upper(),
                 api=api,
             )

--- a/tests/data/v2.0/invalid_swagger_specs_because_ref_in_responses.json
+++ b/tests/data/v2.0/invalid_swagger_specs_because_ref_in_responses.json
@@ -1,0 +1,21 @@
+{
+    "info": {
+        "title": "Test",
+        "version": "1.0"
+    },
+    "paths": {
+        "/endpoint": {
+            "get": {
+                "responses": {
+                    "$ref": "#/responses"
+                }
+            }
+        }
+    },
+    "responses": {
+        "default": {
+            "description": "any response"
+        }
+    },
+    "swagger": "2.0"
+}

--- a/tests/validator20/validate_apis_test.py
+++ b/tests/validator20/validate_apis_test.py
@@ -10,6 +10,13 @@ from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator20 import validate_apis
 
 
+RESPONSES = {
+    'default': {
+        'description': 'random description',
+    },
+}
+
+
 def test_api_level_params_ok():
     # Parameters defined at the API level apply to all operations within that
     # API. Make sure we don't treat the API level parameters as an operation
@@ -25,8 +32,9 @@ def test_api_level_params_ok():
                 },
             ],
             'get': {
-            }
-        }
+                'responses': RESPONSES,
+            },
+        },
     }
     # Success == no exception thrown
     validate_apis(apis, lambda x: x)
@@ -44,7 +52,8 @@ def test_api_level_x_hyphen_ok():
                         'in': 'path',
                         'type': 'string',
                     }
-                ]
+                ],
+                'responses': RESPONSES,
             }
         }
     }
@@ -75,6 +84,7 @@ def test_api_check_default_succeed(partial_parameter_spec):
                 'parameters': [
                     dict({'name': 'param', 'in': 'query'}, **partial_parameter_spec),
                 ],
+                'responses': RESPONSES,
             },
         },
     }
@@ -131,6 +141,7 @@ def test_api_check_default_fails(partial_parameter_spec, validator, instance):
                 'parameters': [
                     dict({'name': 'param', 'in': 'query'}, **partial_parameter_spec),
                 ],
+                'responses': RESPONSES,
             },
         },
     }

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -4,6 +4,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
+import os
+
 import pytest
 from jsonschema.validators import RefResolver
 
@@ -328,3 +331,12 @@ def test_ref_without_str_argument(minimal_swagger_dict):
     not_a_ref = {'properties': {'$ref': {'type': 'string'}}}
     minimal_swagger_dict['definitions']['not_a_ref'] = not_a_ref
     validate_spec(minimal_swagger_dict)
+
+
+def test_failure_because_references_in_operation_responses():
+    my_dir = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(my_dir, '../data/v2.0/invalid_swagger_specs_because_ref_in_responses.json')) as f:
+        invalid_spec = json.load(f)
+    with pytest.raises(SwaggerValidationError) as excinfo:
+        validate_spec(invalid_spec)
+    assert 'GET /endpoint has not valid responses' in str(excinfo.value)

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -339,4 +339,5 @@ def test_failure_because_references_in_operation_responses():
         invalid_spec = json.load(f)
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec(invalid_spec)
-    assert 'GET /endpoint has not valid responses' in str(excinfo.value)
+    assert 'GET /endpoint does not have a valid responses section. ' \
+           'That section cannot be just a reference to another object.' in str(excinfo.value)


### PR DESCRIPTION
Fixes #91 

The goal of this PR is to ensure that references are not allowed into operation responses, more detail on the issue.
