### PR TITLE
Ensure that inline models are parameters are validated

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -393,11 +393,11 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
         visited_definitions_ids.add(id(definition))
 
     if 'allOf' in definition:
-        for inner_definition in definition['allOf']:
+        for idx, inner_definition in enumerate(definition['allOf']):
             validate_definition(
                 definition=inner_definition,
                 deref=deref,
-                def_name=def_name,
+                def_name='{}/{}'.format(def_name, str(idx)),
                 visited_definitions_ids=visited_definitions_ids,
             )
     else:
@@ -447,7 +447,7 @@ def validate_definitions(definitions, deref):
         validate_definition(
             definition=definition,
             deref=deref,
-            def_name=def_name,
+            def_name='#/definitions/{}'.format(def_name),
             visited_definitions_ids=visited_definitions_ids,
         )
 

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -162,6 +162,9 @@ def validate_default_in_parameter(param_spec, deref):
         return
 
     if 'default' in deref_param_spec:
+        if deref_param_spec['default'] is None and deref_param_spec.get('x-nullable', False) is True:
+            # In case x-nullable property is set to true, null is a valid default
+            return
         validate_value_type(
             schema=deref_param_spec,
             value=deref_param_spec['default'],
@@ -362,6 +365,10 @@ def validate_property_default(property_spec, deref):
     """
     deref_property_spec = deref(property_spec)
     if 'default' in deref_property_spec:
+        if deref_property_spec['default'] is None and deref_property_spec.get('x-nullable', False) is True:
+            # In case x-nullable property is set to true, null is a valid default
+            return
+
         validate_value_type(schema=property_spec, value=deref_property_spec['default'], deref=deref)
 
 

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -95,6 +95,7 @@ def validate_spec(spec_dict, spec_url='', http_handlers=None):
     definitions = bound_deref(spec_dict.get('definitions', {}))
     validate_apis(apis, bound_deref)
     validate_definitions(definitions, bound_deref)
+    validate_parameters(bound_deref(spec_dict.get('parameters', {})), bound_deref)
     return swagger_resolver
 
 
@@ -448,6 +449,15 @@ def validate_definitions(definitions, deref):
             deref=deref,
             def_name=def_name,
             visited_definitions_ids=visited_definitions_ids,
+        )
+
+
+def validate_parameters(parameters, deref):
+    for param_name, param_spec in iteritems(parameters):
+        validate_parameter(
+            param=param_spec,
+            deref=deref,
+            def_name='#/parameters/{}'.format(param_name),
         )
 
 

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -213,12 +213,6 @@ def validate_responses(api, http_verb, responses_dict, deref=None):
 
 
 def validate_non_body_parameter(param, deref, def_name):
-    if is_ref(param):
-        return
-
-    if param['in'] == 'body':
-        return
-
     if 'type' not in param:
         raise SwaggerValidationError(
             'Non-Body parameter in `{def_name}` does not specify `type`.'.format(def_name=def_name),
@@ -231,12 +225,6 @@ def validate_non_body_parameter(param, deref, def_name):
 
 
 def validate_body_parameter(param, deref, def_name):
-    if is_ref(param):
-        return
-
-    if param['in'] != 'body':
-        return
-
     if 'schema' not in param:
         raise SwaggerValidationError(
             'Body parameter in `{def_name}` does not specify `schema`.'.format(def_name=def_name)
@@ -252,8 +240,12 @@ def validate_body_parameter(param, deref, def_name):
 
 def validate_parameter(param, deref, def_name):
     validate_default_in_parameter(param, deref)
-    validate_body_parameter(param, deref, def_name)
-    validate_non_body_parameter(param, deref, def_name)
+
+    if not is_ref(param):
+        if param['in'] == 'body':
+            validate_body_parameter(param, deref, def_name)
+        else:
+            validate_non_body_parameter(param, deref, def_name)
 
 
 def validate_apis(apis, deref):

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -208,8 +208,48 @@ def validate_responses(api, http_verb, responses_dict, deref=None):
         )
 
 
+def validate_non_body_parameter(param, deref, def_name):
+    if is_ref(param):
+        return
+
+    if param['in'] == 'body':
+        return
+
+    if 'type' not in param:
+        raise SwaggerValidationError(
+            'Non-Body parameter in `{def_name}` does not specify `type`.'.format(def_name=def_name),
+        )
+
+    if param['type'] == 'array' and 'items' not in param:
+        raise SwaggerValidationError(
+            'Non-Body array parameter in `{def_name}` does not specify `items`.'.format(def_name=def_name),
+        )
+
+
+def validate_body_parameter(param, deref, def_name):
+    if is_ref(param):
+        return
+
+    if param['in'] != 'body':
+        return
+
+    if 'schema' not in param:
+        raise SwaggerValidationError(
+            'Body parameter in `{def_name}` does not specify `schema`.'.format(def_name=def_name)
+        )
+
+    validate_definition(
+        definition=param['schema'],
+        deref=deref,
+        def_name='{}/schema'.format(def_name),
+        visited_definitions_ids=set(),
+    )
+
+
 def validate_parameter(param, deref, def_name):
     validate_default_in_parameter(param, deref)
+    validate_body_parameter(param, deref, def_name)
+    validate_non_body_parameter(param, deref, def_name)
 
 
 def validate_apis(apis, deref):

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -183,7 +183,7 @@ def validate_defaults_in_parameters(params_spec, deref):
         validate_default_in_parameter(param_spec, deref)
 
 
-def validate_responses(api, http_verb, responses_dict):
+def validate_responses(api, http_verb, responses_dict, deref=None):
     if is_ref(responses_dict):
         raise SwaggerValidationError(
             '{http_verb} {api} does not have a valid responses section. '
@@ -191,6 +191,20 @@ def validate_responses(api, http_verb, responses_dict):
                 http_verb=http_verb.upper(),
                 api=api,
             )
+        )
+    for response_status, response_spec in iteritems(responses_dict):
+        response_schema = response_spec.get('schema')
+        if response_schema is None:
+            continue
+        validate_definition(
+            definition=response_schema,
+            deref=deref,
+            def_name='#/paths/{api}/{http_verb}/responses/{status_code}'.format(
+                http_verb=http_verb,
+                api=api,
+                status_code=response_status,
+            ),
+            visited_definitions_ids=set(),
         )
 
 
@@ -260,7 +274,7 @@ def validate_apis(apis, deref):
                     ),
                 )
             # Responses validation
-            validate_responses(api_name, oper_name, oper_body['responses'])
+            validate_responses(api_name, oper_name, oper_body['responses'], deref)
 
 
 def get_collapsed_properties_type_mappings(definition, deref):

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -359,6 +359,14 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
         validate_defaults_in_definition(definition, deref)
         validate_arrays_in_definition(definition, def_name=def_name)
 
+        for property_name, property_spec in iteritems(definition.get('properties', {})):
+            validate_definition(
+                definition=property_spec,
+                deref=deref,
+                def_name='{}/properties/{}'.format(def_name, property_name),
+                visited_definitions_ids=visited_definitions_ids,
+            )
+
     if 'discriminator' in definition:
         required_props, not_required_props = get_collapsed_properties_type_mappings(definition, deref)
         discriminator = definition['discriminator']

--- a/tests/validator20/validate_apis_test.py
+++ b/tests/validator20/validate_apis_test.py
@@ -72,6 +72,7 @@ def test_api_level_x_hyphen_ok():
         {'type': 'object', 'default': {'a_random_property': 'valid'}},
         {'type': 'array', 'items': {'type': 'integer'}, 'default': [5, 6, 7]},
         {'type': 'string', 'default': ''},
+        {'type': 'string', 'default': None, 'x-nullable': True},
         {'type': ['number', 'boolean'], 'default': 8},
         {'type': ['number', 'boolean'], 'default': False},
     ],

--- a/tests/validator20/validate_apis_test.py
+++ b/tests/validator20/validate_apis_test.py
@@ -8,7 +8,7 @@ import pytest
 
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator20 import validate_apis
-
+from swagger_spec_validator.validator20 import validate_defaults_in_parameters
 
 RESPONSES = {
     'default': {
@@ -153,6 +153,24 @@ def test_api_check_default_fails(partial_parameter_spec, validator, instance):
     assert validation_error.validator == validator
 
 
+def test_validate_defaults_in_parameters_succeed():
+    # Success if no exception are raised
+    validate_defaults_in_parameters(
+        params_spec=[{'type': 'integer'}],
+        deref=lambda x: x,
+    )
+
+
+def test_validate_defaults_in_parameters_fails():
+    with pytest.raises(SwaggerValidationError):
+        validate_defaults_in_parameters(
+            params_spec=[
+                {'type': 'integer', 'default': 'wrong_type'},
+            ],
+            deref=lambda x: x,
+        )
+
+
 @pytest.mark.parametrize(
     'apis',
     [
@@ -239,3 +257,81 @@ def test_duplicate_operationIds_fails(apis):
 )
 def test_duplicate_operationIds_succeeds_if_tags_differ(apis):
     validate_apis(apis, lambda x: x)
+
+
+def test_invalid_inline_models_in_responses_fails():
+    apis = {
+        '/endpoint': {
+            'get': {
+                'responses': {
+                    '200': {
+                        'description': 'desc',
+                        'schema': {
+                            'type': 'object',
+                            'properties': {'prop': {'type': 'array'}},
+                        },
+                    },
+                },
+            },
+        },
+    }
+    with pytest.raises(SwaggerValidationError) as excinfo:
+        validate_apis(apis, lambda x: x)
+    assert str(excinfo.value) == 'Definition of type array must define `items` property ' \
+                                 '(definition #/paths//endpoint/get/responses/200/properties/prop).'
+
+
+def test_invalid_inline_models_in_operation_body_parameters_fails():
+    apis = {
+        '/endpoint': {
+            'get': {
+                'parameters': [
+                    {
+                        'in': 'body',
+                        'name': 'body',
+                        'schema': {
+                            'type': 'object',
+                            'properties': {'prop': {'type': 'array'}},
+                        },
+                    }
+                ],
+                'responses': {
+                    '200': {
+                        'description': 'desc',
+                    },
+                },
+            },
+        },
+    }
+    with pytest.raises(SwaggerValidationError) as excinfo:
+        validate_apis(apis, lambda x: x)
+    assert str(excinfo.value) == 'Definition of type array must define `items` property ' \
+                                 '(definition #/paths//endpoint/get/parameters/0/schema/properties/prop).'
+
+
+def test_invalid_inline_models_in_api_body_parameters_fails():
+    apis = {
+        '/endpoint': {
+            'parameters': [
+                {
+                    'in': 'body',
+                    'name': 'body',
+                    'schema': {
+                        'type': 'object',
+                        'properties': {'prop': {'type': 'array'}},
+                    },
+                }
+            ],
+            'get': {
+                'responses': {
+                    '200': {
+                        'description': 'desc',
+                    },
+                },
+            },
+        },
+    }
+    with pytest.raises(SwaggerValidationError) as excinfo:
+        validate_apis(apis, lambda x: x)
+    assert str(excinfo.value) == 'Definition of type array must define `items` property ' \
+                                 '(definition #/paths//endpoint/parameters/0/schema/properties/prop).'

--- a/tests/validator20/validate_apis_test.py
+++ b/tests/validator20/validate_apis_test.py
@@ -70,9 +70,8 @@ def test_api_level_x_hyphen_ok():
         {'type': 'number', 'default': 2},
         {'type': 'number', 'default': 3.4},
         {'type': 'object', 'default': {'a_random_property': 'valid'}},
-        {'type': 'array', 'default': [5, 6, 7]},
+        {'type': 'array', 'items': {'type': 'integer'}, 'default': [5, 6, 7]},
         {'type': 'string', 'default': ''},
-        {'default': -1},  # if type is not defined any value is a valid value
         {'type': ['number', 'boolean'], 'default': 8},
         {'type': ['number', 'boolean'], 'default': False},
     ],

--- a/tests/validator20/validate_definitions_test.py
+++ b/tests/validator20/validate_definitions_test.py
@@ -20,6 +20,7 @@ from swagger_spec_validator.validator20 import validate_definitions
         {'type': 'number', 'default': 3.4},
         {'type': 'object', 'default': {'a_random_property': 'valid'}},
         {'type': 'array', 'items': {'type': 'integer'}, 'default': [5, 6, 7]},
+        {'default': -1},  # if type is not defined any value is a valid value
         {'type': 'string', 'default': ''},
         {'type': ['number', 'boolean'], 'default': 8},
         {'type': ['number', 'boolean'], 'default': False},

--- a/tests/validator20/validate_definitions_test.py
+++ b/tests/validator20/validate_definitions_test.py
@@ -19,9 +19,8 @@ from swagger_spec_validator.validator20 import validate_definitions
         {'type': 'number', 'default': 2},
         {'type': 'number', 'default': 3.4},
         {'type': 'object', 'default': {'a_random_property': 'valid'}},
-        {'type': 'array', 'default': [5, 6, 7]},
+        {'type': 'array', 'items': {'type': 'integer'}, 'default': [5, 6, 7]},
         {'type': 'string', 'default': ''},
-        {'default': -1},  # if type is not defined any value is a valid value
         {'type': ['number', 'boolean'], 'default': 8},
         {'type': ['number', 'boolean'], 'default': False},
     ],

--- a/tests/validator20/validate_definitions_test.py
+++ b/tests/validator20/validate_definitions_test.py
@@ -121,3 +121,21 @@ def test_type_array_without_items_succeed_fails():
         validate_definitions(definitions, lambda x: x)
 
     assert str(excinfo.value) == 'Definition of type array must define `items` property (definition #/definitions/definition_1).'
+
+
+def test_inline_model_is_not_valid_validation_fails():
+    definitions = {
+        'definition_1': {
+            'properties': {
+                'property': {
+                    'type': 'array',
+                },
+            },
+        },
+    }
+
+    with pytest.raises(SwaggerValidationError) as excinfo:
+        validate_definitions(definitions, lambda x: x)
+
+    assert str(excinfo.value) == 'Definition of type array must define `items` property ' \
+                                 '(definition #/definitions/definition_1/properties/property).'

--- a/tests/validator20/validate_definitions_test.py
+++ b/tests/validator20/validate_definitions_test.py
@@ -120,4 +120,4 @@ def test_type_array_without_items_succeed_fails():
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_definitions(definitions, lambda x: x)
 
-    assert str(excinfo.value) == 'Definition of type array must define `items` property (definition definition_1).'
+    assert str(excinfo.value) == 'Definition of type array must define `items` property (definition #/definitions/definition_1).'

--- a/tests/validator20/validate_parameters_test.py
+++ b/tests/validator20/validate_parameters_test.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import pytest
+
+from swagger_spec_validator.common import SwaggerValidationError
+from swagger_spec_validator.validator20 import validate_parameters
+
+
+@pytest.mark.parametrize(
+    'top_level_parameters',
+    [
+        {},
+        {
+            'Offset': {
+                'in': 'query',
+                'name': 'offset',
+                'type': 'integer',
+            },
+        },
+        {
+            'AcceptedLanguage': {
+                'in': 'header',
+                'name': 'Accepted-Language',
+                'type': 'string',
+            },
+        },
+    ]
+)
+def test_valid_top_level_parameters(top_level_parameters):
+    validate_parameters(top_level_parameters, deref=lambda x: x)
+
+
+@pytest.mark.parametrize(
+    'top_level_parameters, expected_exception_string',
+    [
+        [
+            {
+                'Offset': {
+                    'in': 'body',
+                    'name': 'body',
+                },
+            },
+            'Body parameter in `#/parameters/Offset` does not specify `schema`.',
+        ],
+        [
+            {
+                'ParameterWithoutType': {
+                    'in': 'header',
+                    'name': 'a-random-parameter',
+                },
+            },
+            'Non-Body parameter in `#/parameters/ParameterWithoutType` does not specify `type`.',
+        ],
+        [
+            {
+                'ListOfIntegers': {
+                    'in': 'header',
+                    'name': 'Accepted-Language',
+                    'type': 'array',
+                },
+            },
+            'Non-Body array parameter in `#/parameters/ListOfIntegers` does not specify `items`.',
+        ],
+    ]
+)
+def test_invalid_top_level_parameters(top_level_parameters, expected_exception_string):
+    with pytest.raises(SwaggerValidationError) as excinfo:
+        validate_parameters(top_level_parameters, deref=lambda x: x)
+
+    assert str(excinfo.value) == expected_exception_string

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -256,6 +256,7 @@ def default_checks_spec_dict(minimal_swagger_dict):
         {'type': 'object', 'default': {'a_random_property': 'valid'}},
         {'type': 'array', 'items': {'type': 'integer'}, 'default': [5, 6, 7]},
         {'type': 'string', 'default': ''},
+        {'type': 'string', 'default': None, 'x-nullable': True},
         {'default': -1},  # if type is not defined any value is a valid value
         {'type': ['number', 'boolean'], 'default': 8},
         {'type': ['number', 'boolean'], 'default': False},

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -375,3 +375,57 @@ def test_type_array_without_items_succeed_fails(minimal_swagger_dict, swagger_di
         validate_spec(minimal_swagger_dict)
 
     assert str(excinfo.value) == 'Definition of type array must define `items` property (definition definition_1).'
+
+
+INVALID_SCHEMA_OBJECT = {
+    'type': 'object',
+    'properties': {'prop': {'type': 'string', 'default': 1}},
+}
+
+
+@pytest.mark.parametrize(
+    'swagger_dict_override',
+    (
+        {
+            'definitions': {'definition_1': INVALID_SCHEMA_OBJECT},
+        },
+        {
+            'definitions': {'definition_2': {
+                'type': 'object',
+                'properties': {'prop': INVALID_SCHEMA_OBJECT},
+            }},
+        },
+        {
+            'parameters': {
+                'param_body': {'in': 'body', 'name': 'body', 'schema': INVALID_SCHEMA_OBJECT},
+            },
+        },
+        {
+            'paths': {
+                '/endpoint': {
+                    'get': {
+                        'parameters': [{'in': 'body', 'name': 'body', 'schema': INVALID_SCHEMA_OBJECT}],
+                        'responses': {
+                            '200': {'description': 'desc'},
+                        },
+                    },
+                },
+            },
+        },
+        {
+            'paths': {
+                '/endpoint': {
+                    'get': {
+                        'responses': {
+                            '200': {'description': 'desc', 'schema': INVALID_SCHEMA_OBJECT},
+                        },
+                    },
+                },
+            },
+        },
+    )
+)
+def test_highlight_inconsistent_schema_object_validation(minimal_swagger_dict, swagger_dict_override):
+    minimal_swagger_dict.update(swagger_dict_override)
+    with pytest.raises(SwaggerValidationError):
+        validate_spec(minimal_swagger_dict)

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -254,7 +254,7 @@ def default_checks_spec_dict(minimal_swagger_dict):
         {'type': 'number', 'default': 2},
         {'type': 'number', 'default': 3.4},
         {'type': 'object', 'default': {'a_random_property': 'valid'}},
-        {'type': 'array', 'default': [5, 6, 7]},
+        {'type': 'array', 'items': {'type': 'integer'}, 'default': [5, 6, 7]},
         {'type': 'string', 'default': ''},
         {'default': -1},  # if type is not defined any value is a valid value
         {'type': ['number', 'boolean'], 'default': 8},

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -374,7 +374,7 @@ def test_type_array_without_items_succeed_fails(minimal_swagger_dict, swagger_di
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec(minimal_swagger_dict)
 
-    assert str(excinfo.value) == 'Definition of type array must define `items` property (definition definition_1).'
+    assert str(excinfo.value) == 'Definition of type array must define `items` property (definition #/definitions/definition_1).'
 
 
 INVALID_SCHEMA_OBJECT = {


### PR DESCRIPTION
This PR is an attempt to fix #96 .
While working on this changes I've noticed that parameters validation was not performed regards default types, items if of type array, etc; this PR tries to address that too.

I've committed multiple small changes in the hope that this could simplify the review of those changes.

Newly added validations
 * validate that inline definitions (so in `#/definitions/def1/properties/prop/`) are validated as definitions
 * validate that models defined in response schemas are validates as definitions (traversing also the inline definitions)
 * validate that all endpoint parameters are validated (so they define items if type is array, they define type if parameter is not in body and validate body schema as definition)
 * validate all the top level definitions
 * when validating default values we should consider that x-nullable could be present

I've added test cases to highlight the new exception messages.