### PR TITLE
Add appveyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,29 @@
+version: '{build}'
+image: Visual Studio 2017
+
+environment:
+  matrix:
+  # Available python versions and their locations on https://www.appveyor.com/docs/build-environment/#python
+  - PYTHON: C:\Python27-x64
+    TOXENV: py27-default
+  - PYTHON: C:\Python27-x64
+    TOXENV: py27-simplejson
+  - PYTHON: C:\Python35-x64
+    TOXENV: py35-default
+  - PYTHON: C:\Python36-x64
+    TOXENV: py36-default
+
+build: off
+
+install:
+- cmd: SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+- cmd: pip install tox
+
+before_test:
+- cmd: python --version
+- cmd: pip --version
+- cmd: tox --version
+
+test_script:
+- cmd: >-
+    tox

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,5 +25,4 @@ before_test:
 - cmd: tox --version
 
 test_script:
-- cmd: >-
-    tox
+- cmd: tox


### PR DESCRIPTION
In order to be able to address #99 and to ensure that we're not introducing Windows regressions into the library I'm adding AppVeyor CI system.

AppVeyor, like travis, is integrated into GitHub and is free for open source projects.

NOTE: This does not address #99 but ensures that we're running tests on Windows too