### PR TITLE
[Windows] Fix urlopen for files

### DIFF
--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -5,10 +5,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import contextlib
+import os
 import sys
 
 import six
 from six.moves.urllib.parse import urljoin
+from six.moves.urllib.request import pathname2url
 from six.moves.urllib.request import urlopen
 from yaml import safe_load
 
@@ -28,6 +30,10 @@ def wrap_exception(method):
     return wrapper
 
 
+def get_uri_from_file_path(file_path):
+    return urljoin('file://', pathname2url(os.path.abspath(file_path)))
+
+
 def read_file(file_path):
     """
     Utility method for reading a JSON/YAML file and converting it to a Python dictionary
@@ -36,7 +42,7 @@ def read_file(file_path):
     :return: Python dictionary representation of the JSON file
     :rtype: dict
     """
-    return read_url(urljoin('file://', file_path))
+    return read_url(get_uri_from_file_path(file_path))
 
 
 def read_url(url, timeout=TIMEOUT_SEC):

--- a/swagger_spec_validator/validator12.py
+++ b/swagger_spec_validator/validator12.py
@@ -22,6 +22,7 @@ from jsonschema import RefResolver
 from pkg_resources import resource_filename
 from six.moves.urllib.parse import urlparse
 
+from swagger_spec_validator.common import get_uri_from_file_path
 from swagger_spec_validator.common import read_file
 from swagger_spec_validator.common import read_url
 from swagger_spec_validator.common import SwaggerValidationError
@@ -259,7 +260,7 @@ def validate_json(json_document, schema_path):
     schema = read_file(schema_path)
 
     resolver = RefResolver(
-        base_uri='file://{}'.format(schema_path),
+        base_uri=get_uri_from_file_path(schema_path),
         referrer=schema,
         handlers=default_handlers,
     )

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -16,6 +16,7 @@ from six import iteritems
 from six import iterkeys
 
 from swagger_spec_validator import ref_validators
+from swagger_spec_validator.common import get_uri_from_file_path
 from swagger_spec_validator.common import read_file
 from swagger_spec_validator.common import read_url
 from swagger_spec_validator.common import SwaggerValidationError
@@ -121,7 +122,7 @@ def validate_json(spec_dict, schema_path, spec_url='', http_handlers=None):
     schema = read_file(schema_path)
 
     schema_resolver = RefResolver(
-        base_uri='file://{}'.format(schema_path),
+        base_uri=get_uri_from_file_path(schema_path),
         referrer=schema,
         handlers=default_handlers,
     )

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -4,10 +4,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
-
 from swagger_spec_validator.common import read_file
 
 
 def test_read_file():
-    read_file(os.path.join(os.path.dirname(__file__), 'data/v2.0/petstore.json'))
+    read_file('./tests/data/v2.0/petstore.json')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,15 @@ from six.moves.urllib.request import pathname2url
 
 
 def is_urlopen_error(exception):
-    return '<urlopen error [Errno -2] Name or service not known>' in str(exception) or \
-           '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(exception) or \
-           '<urlopen error [Errno -5] No address associated with hostname>' in str(exception)
+    return any(
+        urlopen_error_str in str(exception)
+        for urlopen_error_str in {
+            '<urlopen error [Errno -2] Name or service not known>',
+            '<urlopen error [Errno 8] nodename nor servname provided, or not known',
+            '<urlopen error [Errno -5] No address associated with hostname>',
+            '<urlopen error [Errno 11001] getaddrinfo failed>',
+        }
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,6 @@ from __future__ import unicode_literals
 import os
 
 import pytest
-from six.moves.urllib.parse import urljoin
-from six.moves.urllib.request import pathname2url
 
 
 def is_urlopen_error(exception):
@@ -36,7 +34,3 @@ def change_dir():
         yield
     finally:
         os.chdir(current_directory)
-
-
-def get_uri_from_file_path(file_path):
-    return urljoin('file://', pathname2url(file_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,33 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
+
+import pytest
+from six.moves.urllib.parse import urljoin
+from six.moves.urllib.request import pathname2url
+
 
 def is_urlopen_error(exception):
     return '<urlopen error [Errno -2] Name or service not known>' in str(exception) or \
            '<urlopen error [Errno 8] nodename nor servname provided, or not known' in str(exception) or \
            '<urlopen error [Errno -5] No address associated with hostname>' in str(exception)
+
+
+@pytest.fixture(autouse=True)
+def change_dir():
+    """
+    Change the base directory to git root directory such that tests does not need to
+    generate the absolute path for the data files.
+    A relative path from git top-level directory will work as well
+    """
+    current_directory = os.path.abspath(os.curdir)
+    try:
+        os.chdir(os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+        yield
+    finally:
+        os.chdir(current_directory)
+
+
+def get_uri_from_file_path(file_path):
+    return urljoin('file://', pathname2url(file_path))

--- a/tests/validator12/run_test.py
+++ b/tests/validator12/run_test.py
@@ -38,12 +38,10 @@ def run_json_tests_with_func(json_test_paths, func):
 
 
 def test_main():
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-
     run_json_tests_with_func(
-        glob.glob(os.path.join(my_dir, '../data/v1.2/api_declarations/*.json')),
+        glob.glob('./tests/data/v1.2/api_declarations/*.json'),
         validate_api_declaration)
 
     run_json_tests_with_func(
-        glob.glob(os.path.join(my_dir, '../data/v1.2/resource_listings/*.json')),
+        glob.glob('./tests/data/v1.2/resource_listings/*.json'),
         validate_resource_listing)

--- a/tests/validator12/validate_json_test.py
+++ b/tests/validator12/validate_json_test.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
-import os
 
 import pytest
 
@@ -14,13 +13,11 @@ from swagger_spec_validator.validator12 import validate_json
 
 
 def test_success():
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-
-    with open(os.path.join(my_dir, '../data/v1.2/foo/swagger_api.json')) as f:
+    with open('./tests/data/v1.2/foo/swagger_api.json') as f:
         resource_listing = json.load(f)
     validate_json(resource_listing, 'schemas/v1.2/resourceListing.json')
 
-    with open(os.path.join(my_dir, '../data/v1.2/foo/foo.json')) as f:
+    with open('./tests/data/v1.2/foo/foo.json') as f:
         api_declaration = json.load(f)
     validate_json(api_declaration, 'schemas/v1.2/apiDeclaration.json')
 

--- a/tests/validator12/validate_spec_test.py
+++ b/tests/validator12/validate_spec_test.py
@@ -11,12 +11,12 @@ import pytest
 
 from .validate_spec_url_test import make_mock_responses
 from .validate_spec_url_test import read_contents
+from swagger_spec_validator.common import get_uri_from_file_path
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator12 import validate_data_type
 from swagger_spec_validator.validator12 import validate_model
 from swagger_spec_validator.validator12 import validate_parameter
 from swagger_spec_validator.validator12 import validate_spec
-from tests.conftest import get_uri_from_file_path
 
 
 RESOURCE_LISTING_FILE = os.path.abspath('tests/data/v1.2/foo/swagger_api.json')

--- a/tests/validator12/validate_spec_test.py
+++ b/tests/validator12/validate_spec_test.py
@@ -16,6 +16,7 @@ from swagger_spec_validator.validator12 import validate_data_type
 from swagger_spec_validator.validator12 import validate_model
 from swagger_spec_validator.validator12 import validate_parameter
 from swagger_spec_validator.validator12 import validate_spec
+from tests.conftest import get_uri_from_file_path
 
 
 RESOURCE_LISTING_FILE = os.path.abspath('tests/data/v1.2/foo/swagger_api.json')
@@ -40,8 +41,10 @@ def test_http_success():
 def test_file_uri_success():
     mock_string = 'swagger_spec_validator.validator12.validate_api_declaration'
     with mock.patch(mock_string) as mock_api:
-        validate_spec(get_resource_listing(),
-                      'file://{}'.format(RESOURCE_LISTING_FILE))
+        validate_spec(
+            get_resource_listing(),
+            get_uri_from_file_path(RESOURCE_LISTING_FILE),
+        )
 
         expected = read_contents(API_DECLARATION_FILE)
         mock_api.assert_called_once_with(expected)

--- a/tests/validator12/validate_spec_url_test.py
+++ b/tests/validator12/validate_spec_url_test.py
@@ -12,6 +12,7 @@ import pytest
 
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator12 import validate_spec_url
+from tests.conftest import get_uri_from_file_path
 from tests.conftest import is_urlopen_error
 
 RESOURCE_LISTING_FILE = os.path.abspath('tests/data/v1.2/foo/swagger_api.json')
@@ -46,7 +47,7 @@ def test_http_success():
 def test_file_uri_success():
     mock_string = 'swagger_spec_validator.validator12.validate_api_declaration'
     with mock.patch(mock_string) as mock_api:
-        validate_spec_url('file://{}'.format(RESOURCE_LISTING_FILE))
+        validate_spec_url(get_uri_from_file_path(RESOURCE_LISTING_FILE))
 
         expected = read_contents(API_DECLARATION_FILE)
         mock_api.assert_called_once_with(expected)

--- a/tests/validator12/validate_spec_url_test.py
+++ b/tests/validator12/validate_spec_url_test.py
@@ -10,9 +10,9 @@ import os
 import mock
 import pytest
 
+from swagger_spec_validator.common import get_uri_from_file_path
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator12 import validate_spec_url
-from tests.conftest import get_uri_from_file_path
 from tests.conftest import is_urlopen_error
 
 RESOURCE_LISTING_FILE = os.path.abspath('tests/data/v1.2/foo/swagger_api.json')

--- a/tests/validator20/conftest.py
+++ b/tests/validator20/conftest.py
@@ -8,13 +8,13 @@ import json
 import os
 
 import pytest
-from six.moves.urllib import parse as urlparse
+
+from tests.conftest import get_uri_from_file_path
 
 
 @pytest.fixture(scope='session')
 def petstore_contents():
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(my_dir, '../data/v2.0/petstore.json')) as f:
+    with open('./tests/data/v2.0/petstore.json') as f:
         return f.read()
 
 
@@ -23,8 +23,7 @@ def petstore_dict(petstore_contents):
     return json.loads(petstore_contents)
 
 
-def get_spec_json_and_url(rel_url):
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-    abs_path = os.path.realpath(os.path.join(my_dir, rel_url))
+def get_spec_json_and_url(rel_path):
+    abs_path = os.path.abspath(rel_path)
     with open(abs_path) as f:
-        return json.loads(f.read()), urlparse.urljoin('file:', abs_path)
+        return json.loads(f.read()), get_uri_from_file_path(abs_path)

--- a/tests/validator20/conftest.py
+++ b/tests/validator20/conftest.py
@@ -9,7 +9,7 @@ import os
 
 import pytest
 
-from tests.conftest import get_uri_from_file_path
+from swagger_spec_validator.common import get_uri_from_file_path
 
 
 @pytest.fixture(scope='session')

--- a/tests/validator20/get_collapsed_properties_map_test.py
+++ b/tests/validator20/get_collapsed_properties_map_test.py
@@ -21,7 +21,7 @@ def get_deref(spec_dict):
 
 
 def test_get_collapsed_properties_type_mapping_simple_case():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     required_parameters, not_required_parameters = get_collapsed_properties_type_mappings(
@@ -33,7 +33,7 @@ def test_get_collapsed_properties_type_mapping_simple_case():
 
 
 def test_get_collapsed_properties_type_mapping_allOf_add_required_property():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     required_parameters, not_required_parameters = get_collapsed_properties_type_mappings(
@@ -45,7 +45,7 @@ def test_get_collapsed_properties_type_mapping_allOf_add_required_property():
 
 
 def test_get_collapsed_properties_type_mapping_allOf_add_not_required_property():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     required_parameters, not_required_parameters = get_collapsed_properties_type_mappings(

--- a/tests/validator20/validate_json_test.py
+++ b/tests/validator20/validate_json_test.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
-import os
 
 import pytest
 
@@ -14,8 +13,7 @@ from swagger_spec_validator.validator20 import validate_json
 
 
 def test_success():
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(my_dir, '../data/v2.0/petstore.json')) as f:
+    with open('./tests/data/v2.0/petstore.json') as f:
         petstore_spec = json.load(f)
     validate_json(petstore_spec, 'schemas/v2.0/schema.json')
 

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
-import os
 
 import pytest
 from jsonschema.validators import RefResolver
@@ -56,7 +55,7 @@ def test_api_parameters_as_refs():
     #
     # and then export it to a json file.
     instagram_specs, _ = get_spec_json_and_url(
-        '../data/v2.0/instagram.json'
+        './tests/data/v2.0/instagram.json'
     )
     validate_spec(instagram_specs)
 
@@ -67,7 +66,7 @@ def test_fails_on_invalid_external_ref_in_dict():
     # key in the parameter is missing.
 
     petstore_spec, petstore_url = get_spec_json_and_url(
-        '../data/v2.0/test_fails_on_invalid_external_ref/petstore.json'
+        './tests/data/v2.0/test_fails_on_invalid_external_ref/petstore.json'
     )
 
     with pytest.raises(SwaggerValidationError) as excinfo:
@@ -81,7 +80,7 @@ def test_fails_on_invalid_external_ref_in_list():
     # The contents of the external ref (pet.json#/get_all_parameters) is not
     # - the 'name' key in the parameter is missing.
     petstore_spec, petstore_url = get_spec_json_and_url(
-        '../data/v2.0/test_fails_on_invalid_external_ref_in_list/petstore.json'
+        './tests/data/v2.0/test_fails_on_invalid_external_ref_in_list/petstore.json'
     )
 
     with pytest.raises(SwaggerValidationError) as excinfo:
@@ -126,7 +125,7 @@ def test_complicated_refs():
     # Split the swagger spec into a bunch of different json files and use
     # $refs all over to place to wire stuff together - see the test-data
     # files or this will make no sense whatsoever.
-    file_path = '../../tests/data/v2.0/test_complicated_refs/swagger.json'
+    file_path = './tests/data/v2.0/test_complicated_refs/swagger.json'
     swagger_dict, origin_url = get_spec_json_and_url(file_path)
     resolver = validate_spec(swagger_dict, spec_url=origin_url)
 
@@ -135,22 +134,22 @@ def test_complicated_refs():
     #   exception was not thrown, there should be 8 cached refs in the
     #   resolver's store:
     #
-    #   6 json files from ../../tests/data/v2.0/tests_complicated_refs/*
-    #   1 yaml files from ../../tests/data/v2.0/tests_complicated_refs/*
+    #   6 json files from tests/data/v2.0/tests_complicated_refs/*
+    #   1 yaml files from tests/data/v2.0/tests_complicated_refs/*
     #   1 draft3 spec
     #   1 draft4 spec
     assert len(resolver.store) == 9
 
 
 def test_specs_with_discriminator():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     validate_spec(swagger_dict)
 
 
 def test_specs_with_discriminator_fail_because_not_required():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     swagger_dict['definitions']['GenericPet']['discriminator'] = 'name'
@@ -161,7 +160,7 @@ def test_specs_with_discriminator_fail_because_not_required():
 
 
 def test_specs_with_discriminator_fail_because_not_string():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     swagger_dict['definitions']['GenericPet']['discriminator'] = 'weight'
@@ -172,7 +171,7 @@ def test_specs_with_discriminator_fail_because_not_string():
 
 
 def test_specs_with_discriminator_fail_because_not_in_properties():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     swagger_dict['definitions']['GenericPet']['discriminator'] = 'an_other_property'
@@ -183,14 +182,14 @@ def test_specs_with_discriminator_fail_because_not_in_properties():
 
 
 def test_specs_with_discriminator_in_allOf():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     validate_spec(swagger_dict)
 
 
 def test_specs_with_discriminator_in_allOf_fail_because_not_required():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     swagger_dict['definitions']['BaseObject']['discriminator'] = 'name'
@@ -201,7 +200,7 @@ def test_specs_with_discriminator_in_allOf_fail_because_not_required():
 
 
 def test_specs_with_discriminator_in_allOf_fail_because_not_string():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     swagger_dict['definitions']['BaseObject']['discriminator'] = 'weight'
@@ -212,7 +211,7 @@ def test_specs_with_discriminator_in_allOf_fail_because_not_string():
 
 
 def test_specs_with_discriminator_in_allOf_fail_because_not_in_properties():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     swagger_dict['definitions']['BaseObject']['discriminator'] = 'an_other_property'
@@ -223,7 +222,7 @@ def test_specs_with_discriminator_in_allOf_fail_because_not_in_properties():
 
 
 def test_read_yaml_specs():
-    file_path = '../../tests/data/v2.0/test_polymorphic_specs/swagger.json'
+    file_path = './tests/data/v2.0/test_polymorphic_specs/swagger.json'
     swagger_dict, _ = get_spec_json_and_url(file_path)
 
     swagger_dict['definitions']['BaseObject']['discriminator'] = 'an_other_property'
@@ -335,8 +334,7 @@ def test_ref_without_str_argument(minimal_swagger_dict):
 
 
 def test_failure_because_references_in_operation_responses():
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(my_dir, '../data/v2.0/invalid_swagger_specs_because_ref_in_responses.json')) as f:
+    with open('./tests/data/v2.0/invalid_swagger_specs_because_ref_in_responses.json') as f:
         invalid_spec = json.load(f)
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_spec(invalid_spec)

--- a/tests/validator20/validate_spec_url_test.py
+++ b/tests/validator20/validate_spec_url_test.py
@@ -12,6 +12,7 @@ import pytest
 
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator20 import validate_spec_url
+from tests.conftest import get_uri_from_file_path
 from tests.conftest import is_urlopen_error
 
 
@@ -25,16 +26,12 @@ def test_success(petstore_contents):
 
 
 def test_success_crossref_url_yaml():
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-    urlpath = "file://{}".format(os.path.join(
-        my_dir, "../data/v2.0/minimal.yaml"))
+    urlpath = get_uri_from_file_path(os.path.abspath("./tests/data/v2.0/minimal.yaml"))
     validate_spec_url(urlpath)
 
 
 def test_success_crossref_url_json():
-    my_dir = os.path.abspath(os.path.dirname(__file__))
-    urlpath = "file://{}".format(os.path.join(
-        my_dir, "../data/v2.0/relative_ref.json"))
+    urlpath = get_uri_from_file_path(os.path.abspath('./tests/data/v2.0/relative_ref.json'))
     validate_spec_url(urlpath)
 
 

--- a/tests/validator20/validate_spec_url_test.py
+++ b/tests/validator20/validate_spec_url_test.py
@@ -10,9 +10,9 @@ import os
 import mock
 import pytest
 
+from swagger_spec_validator.common import get_uri_from_file_path
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator20 import validate_spec_url
-from tests.conftest import get_uri_from_file_path
 from tests.conftest import is_urlopen_error
 
 


### PR DESCRIPTION
This fixes #99 

The issue happens as given an absolute path (ie. `C:\Directory\file.json`) the related URI was built as `file://<absolute path>`.
This is not correct on Windows platform as backslashes need to be converted to slashes and the path should be prefixed by `/` (`file:///c:/Directory/file.json`).

urllib exposes a utility function to perform those actions `pathname2url`.

The majority of the provided changes are related to tests files as:
 * the file URIs were _manually_ built all the time -> let's use a helper for it
 * simplify the definition of the absolute paths by defining a pytest autouse fixture that `chdir`s into git root directory

Windows test results on https://ci.appveyor.com/project/macisamuele/swagger-spec-validator/build/1