### PR TITLE
Disallow multiple types in schema definitions

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -392,6 +392,11 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
             return
         visited_definitions_ids.add(id(definition))
 
+    swagger_type = definition.get('type')
+    if isinstance(swagger_type, list):
+        # not valid Swagger; see https://github.com/OAI/OpenAPI-Specification/issues/458
+        raise SwaggerValidationError('type must be a string; lists are not allowed (%s)' % swagger_type)
+
     if 'allOf' in definition:
         for idx, inner_definition in enumerate(definition['allOf']):
             validate_definition(

--- a/tests/validator20/validate_definitions_test.py
+++ b/tests/validator20/validate_definitions_test.py
@@ -101,7 +101,7 @@ def test_multiple_types_fail():
     with pytest.raises(SwaggerValidationError) as excinfo:
         validate_definitions(definitions, lambda x: x)
 
-    assert excinfo.value.args[0] == "type must be a string; lists are not allowed (['number', 'boolean'])"
+    assert excinfo.value.args[0].startswith('type must be a string; lists are not allowed')
 
 
 def test_type_array_with_items_succeed_validation():

--- a/tests/validator20/validate_definitions_test.py
+++ b/tests/validator20/validate_definitions_test.py
@@ -22,8 +22,6 @@ from swagger_spec_validator.validator20 import validate_definitions
         {'type': 'array', 'items': {'type': 'integer'}, 'default': [5, 6, 7]},
         {'default': -1},  # if type is not defined any value is a valid value
         {'type': 'string', 'default': ''},
-        {'type': ['number', 'boolean'], 'default': 8},
-        {'type': ['number', 'boolean'], 'default': False},
     ],
 )
 def test_api_check_default_succeed(property_spec):
@@ -74,10 +72,6 @@ def test_api_check_default_succeed(property_spec):
             {'type': 'string', 'minLength': 100, 'default': 'short_string'},
             'minLength', 'short_string',
         ],
-        [
-            {'type': ['number', 'boolean'], 'default': 'not_a_number_or_boolean'},
-            'type', 'not_a_number_or_boolean',
-        ],
     ],
 )
 def test_api_check_default_fails(property_spec, validator, instance):
@@ -95,6 +89,19 @@ def test_api_check_default_fails(property_spec, validator, instance):
     validation_error = excinfo.value.args[1]
     assert validation_error.instance == instance
     assert validation_error.validator == validator
+
+
+def test_multiple_types_fail():
+    definitions = {
+        'definition_1': {
+            'type': ['number', 'boolean'],
+        },
+    }
+
+    with pytest.raises(SwaggerValidationError) as excinfo:
+        validate_definitions(definitions, lambda x: x)
+
+    assert excinfo.value.args[0] == "type must be a string; lists are not allowed (['number', 'boolean'])"
 
 
 def test_type_array_with_items_succeed_validation():

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -257,8 +257,6 @@ def default_checks_spec_dict(minimal_swagger_dict):
         {'type': 'string', 'default': ''},
         {'type': 'string', 'default': None, 'x-nullable': True},
         {'default': -1},  # if type is not defined any value is a valid value
-        {'type': ['number', 'boolean'], 'default': 8},
-        {'type': ['number', 'boolean'], 'default': False},
         {'type': 'array', 'items': {'$ref': '#/definitions/bool_string'}, 'default': [{'value': 'False'}]},
     ],
 )


### PR DESCRIPTION
Swagger 2 does not support a schema object having multiple types. This is not explicitly called out in the spec, and there's confusion around it since JSONSchema draft 4 does allow multiple types. The spec maintainers have publicly stated that multiple types are not supported (see OAI/OpenAPI-Specification#458) and have clarified the spec for [OpenAPI 3 to mention that fact](https://swagger.io/docs/specification/data-models/data-types/).

Additionally, our tooling around Swagger generally does not support multiple types either. So let's make sure swagger_spec_validator reports this problem.