### PR TITLE
Add warning if none in ref

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -33,10 +33,9 @@ log = logging.getLogger(__name__)
 
 
 def validate_ref(ref_dict, path):
-    """Check if a ref_dict has siblings that will be overwritten by $ref. Raise
-    a SwaggerValidationError if extra items are found in ref_dict.
+    """Check if a ref_dict has siblings that will be overwritten by $ref or $ref is None.
 
-    While this does not contradict the spec, it may cause confusion and mislead
+    While the siblings case does not contradict the spec, it may cause confusion and mislead
     developers. See https://stackoverflow.com/a/48114924.
 
     :param ref_dict: A dict that may be {'$ref': '#/blah/blah', 'x-nullable': true}.
@@ -59,9 +58,8 @@ def validate_ref(ref_dict, path):
     if ref_dict['$ref'] is None:
         warnings.warn(
             SwaggerValidationWarning(
-                'Identified $ref with None value. This usually represent an error on the specs even '
-                'if this does not make them invalid as the location of the reference could tolerate '
-                'a None value. (path {})'.format('/'.join(path)),
+                'Identified $ref with None value. This is usually an error, '
+                'although technically it might be allowed. (path: {})'.format('/'.join(path)),
             ),
         )
 

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -77,8 +77,15 @@ def validate_references(raw_spec, deref, path=None, visited_spec_ids=None):
     # Register raw_spec into visited_spec_ids to prevent unbounded recursion
     visited_spec_ids.add(id(raw_spec))
 
-    if is_ref(raw_spec):
+    if isinstance(raw_spec, dict) and '$ref' in raw_spec:
+        # The additional check is needed as `is_ref` will consider raw_spec dictionaries with `$ref`
+        # attribute and string value.
+        # The goal of validate_ref is to ensure that objects that looks like a reference is actually
+        # valid by warning users about those cases.
+        # Due to _looks like_ we need to almost duplicate the check by removing the string enforcement
         validate_ref(ref_dict=raw_spec, path=path)
+
+    if is_ref(raw_spec):
         if isinstance(raw_spec['$ref'], string_types):
             validate_references(deref(raw_spec), deref, path, visited_spec_ids)
     elif isinstance(raw_spec, dict):

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -590,4 +590,4 @@ def validate_unresolvable_path_params(path_name, path_params):
 
 
 def is_ref(spec_dict):
-    return isinstance(spec_dict, dict) and '$ref' in spec_dict
+    return isinstance(spec_dict, dict) and isinstance(spec_dict.get('$ref'), string_types)

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -84,7 +84,7 @@ def validate_references(raw_spec, deref, path=None, visited_spec_ids=None):
         if isinstance(raw_spec['$ref'], string_types):
             validate_references(deref(raw_spec), deref, path, visited_spec_ids)
     elif isinstance(raw_spec, dict):
-        for k, v in iteritems(raw_spec):
+        for k, v in sorted(iteritems(raw_spec)):
             validate_references(v, deref, path + [k], visited_spec_ids)
     elif isinstance(raw_spec, list):
         for k, v in enumerate(raw_spec):

--- a/tests/data/v2.0/invalid_swagger_spec_because_empty_reference.yaml
+++ b/tests/data/v2.0/invalid_swagger_spec_because_empty_reference.yaml
@@ -1,0 +1,19 @@
+info:
+  title: Test
+  version: '1.0'
+definitions:
+  model1:
+    type: object
+    x-extends:
+      $ref: #/definitions/model2
+  model2:
+    type: object
+paths:
+  /endpoint:
+    get:
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/model1'
+swagger: '2.0'

--- a/tests/validator20/deref_test.py
+++ b/tests/validator20/deref_test.py
@@ -4,14 +4,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import warnings
-
 import pytest
 from jsonschema.exceptions import RefResolutionError
 from jsonschema.validators import RefResolver
 from mock import Mock
 
-from swagger_spec_validator.common import SwaggerValidationWarning
 from swagger_spec_validator.validator20 import deref
 
 
@@ -36,18 +33,6 @@ def test_ref():
         }
     }
     assert deref(ref_dict, RefResolver('', definitions)) == 'bar'
-
-
-def test_invalid_ref():
-    ref_dict = {'$ref': '#/definitions/Foo', 'x-nullable': True}
-    definitions = {
-        'definitions': {
-            'Foo': 'bar'
-        }
-    }
-    with warnings.catch_warnings(record=True) as warnings_list:
-        deref(ref_dict, RefResolver('', definitions))
-        assert warnings_list[0].category == SwaggerValidationWarning
 
 
 def test_ref_not_found():

--- a/tests/validator20/validate_references_test.py
+++ b/tests/validator20/validate_references_test.py
@@ -10,17 +10,17 @@ from swagger_spec_validator.common import SwaggerValidationWarning
 from swagger_spec_validator.validator20 import validate_references
 
 
-# @pytest.mark.parametrize(
-#     'raw_spec',
-#     [
-#         {'$ref': '#/'},
-#         {'description': 'Description sibling is acceptable', '$ref': '#/'},
-#         [{'$ref': '#/'}],
-#     ],
-# )
-# def test_validate_valid_references(recwarn, raw_spec):
-#     validate_references(raw_spec=raw_spec, deref=lambda x: x)
-#     assert len(recwarn) == 0
+@pytest.mark.parametrize(
+    'raw_spec',
+    [
+        {'$ref': '#/'},
+        {'description': 'Description sibling is acceptable', '$ref': '#/'},
+        [{'$ref': '#/'}],
+    ],
+)
+def test_validate_valid_references(recwarn, raw_spec):
+    validate_references(raw_spec=raw_spec, deref=lambda x: x)
+    assert len(recwarn) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/validator20/validate_references_test.py
+++ b/tests/validator20/validate_references_test.py
@@ -43,17 +43,15 @@ def test_validate_valid_references(recwarn, raw_spec):
         (
             {'$ref': None},
             (
-                'Identified $ref with None value. This usually represent an error on the specs even '
-                'if this does not make them invalid as the location of the reference could tolerate '
-                'a None value. (path #)',
+                'Identified $ref with None value. This is usually an error, although technically it might be allowed. '
+                '(path: #)',
             ),
         ),
         (
             {'key': {'$ref': None}},
             (
-                'Identified $ref with None value. This usually represent an error on the specs even '
-                'if this does not make them invalid as the location of the reference could tolerate '
-                'a None value. (path #/key)',
+                'Identified $ref with None value. This is usually an error, although technically it might be allowed. '
+                '(path: #/key)',
             ),
         ),
         (
@@ -61,9 +59,8 @@ def test_validate_valid_references(recwarn, raw_spec):
             (
                 'Found "$ref: None" with siblings that will be overwritten. '
                 'See https://stackoverflow.com/a/48114924 for more information. (path #/key/0)',
-                'Identified $ref with None value. This usually represent an error on the specs even '
-                'if this does not make them invalid as the location of the reference could tolerate '
-                'a None value. (path #/key/0)',
+                'Identified $ref with None value. This is usually an error, although technically it might be allowed. '
+                '(path: #/key/0)',
             ),
         ),
     ],

--- a/tests/validator20/validate_references_test.py
+++ b/tests/validator20/validate_references_test.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import pytest
+
+from swagger_spec_validator.common import SwaggerValidationWarning
+from swagger_spec_validator.validator20 import validate_references
+
+
+# @pytest.mark.parametrize(
+#     'raw_spec',
+#     [
+#         {'$ref': '#/'},
+#         {'description': 'Description sibling is acceptable', '$ref': '#/'},
+#         [{'$ref': '#/'}],
+#     ],
+# )
+# def test_validate_valid_references(recwarn, raw_spec):
+#     validate_references(raw_spec=raw_spec, deref=lambda x: x)
+#     assert len(recwarn) == 0
+
+
+@pytest.mark.parametrize(
+    'raw_spec, expected_warning_messages',
+    [
+        (
+            {'sibling-attribute': '', '$ref': '#/'},
+            (
+                'Found "$ref: #/" with siblings that will be overwritten. '
+                'See https://stackoverflow.com/a/48114924 for more information. (path #)',
+            ),
+        ),
+        (
+            [{'sibling-attribute': '', '$ref': '#/'}],
+            (
+                'Found "$ref: #/" with siblings that will be overwritten. '
+                'See https://stackoverflow.com/a/48114924 for more information. (path #/0)',
+            ),
+        ),
+        (
+            {'$ref': None},
+            (
+                'Identified $ref with None value. This usually represent an error on the specs even '
+                'if this does not make them invalid as the location of the reference could tolerate '
+                'a None value. (path #)',
+            ),
+        ),
+        (
+            {'key': {'$ref': None}},
+            (
+                'Identified $ref with None value. This usually represent an error on the specs even '
+                'if this does not make them invalid as the location of the reference could tolerate '
+                'a None value. (path #/key)',
+            ),
+        ),
+        (
+            {'key': [{'sibling-attribute': 1, '$ref': None}]},
+            (
+                'Found "$ref: None" with siblings that will be overwritten. '
+                'See https://stackoverflow.com/a/48114924 for more information. (path #/key/0)',
+                'Identified $ref with None value. This usually represent an error on the specs even '
+                'if this does not make them invalid as the location of the reference could tolerate '
+                'a None value. (path #/key/0)',
+            ),
+        ),
+    ],
+)
+def test_validate_references_to_warn(raw_spec, expected_warning_messages):
+    with pytest.warns(SwaggerValidationWarning) as warninfo:
+        validate_references(raw_spec=raw_spec, deref=lambda x: x)
+
+    assert sorted(expected_warning_messages) == sorted(str(warning.message) for warning in warninfo.list)

--- a/tests/validator20/validate_spec_url_test.py
+++ b/tests/validator20/validate_spec_url_test.py
@@ -44,9 +44,8 @@ def test_specs_with_empty_reference():
             ),
         )
 
-    assert 'Identified $ref with None value. This usually represent an error on the specs even if this does not make ' \
-           'them invalid as the location of the reference could tolerate a None value. ' \
-           '(path #/definitions/model1/x-extends)' == str(warninfo.list[0].message)
+    assert 'Identified $ref with None value. This is usually an error, although technically it might be allowed. ' \
+           '(path: #/definitions/model1/x-extends)' == str(warninfo.list[0].message)
 
 
 def test_raise_SwaggerValidationError_on_urlopen_error():

--- a/tests/validator20/validate_spec_url_test.py
+++ b/tests/validator20/validate_spec_url_test.py
@@ -12,14 +12,15 @@ import pytest
 
 from swagger_spec_validator.common import get_uri_from_file_path
 from swagger_spec_validator.common import SwaggerValidationError
+from swagger_spec_validator.common import SwaggerValidationWarning
 from swagger_spec_validator.validator20 import validate_spec_url
 from tests.conftest import is_urlopen_error
 
 
 def test_success(petstore_contents):
     with mock.patch(
-            'swagger_spec_validator.validator20.read_url',
-            return_value=json.loads(petstore_contents),
+        'swagger_spec_validator.validator20.read_url',
+        return_value=json.loads(petstore_contents),
     ) as mock_read_url:
         validate_spec_url('http://localhost/api-docs')
         mock_read_url.assert_called_once_with('http://localhost/api-docs')
@@ -33,6 +34,19 @@ def test_success_crossref_url_yaml():
 def test_success_crossref_url_json():
     urlpath = get_uri_from_file_path(os.path.abspath('./tests/data/v2.0/relative_ref.json'))
     validate_spec_url(urlpath)
+
+
+def test_specs_with_empty_reference():
+    with pytest.warns(SwaggerValidationWarning) as warninfo:
+        validate_spec_url(
+            get_uri_from_file_path(
+                os.path.abspath('./tests/data/v2.0/invalid_swagger_spec_because_empty_reference.yaml'),
+            ),
+        )
+
+    assert 'Identified $ref with None value. This usually represent an error on the specs even if this does not make ' \
+           'them invalid as the location of the reference could tolerate a None value. ' \
+           '(path #/definitions/model1/x-extends)' == str(warninfo.list[0].message)
 
 
 def test_raise_SwaggerValidationError_on_urlopen_error():


### PR DESCRIPTION
While working on some internal fixes I did noticed that swagger-spec-validate does not always ensure that the content of `$ref` is valid.
My specific issue was mostly happening because a reference was set on a point of the specs were _anything_ would be valid (in a vendor extension).
I do think that having a warning in such case would be valuable to communicate to users eventual problems with theirs specs.

Check [`invalid_swagger_spec_because_empty_reference.yaml`](https://github.com/Yelp/swagger_spec_validator/compare/master...macisamuele:maci-add-warning-if-None-in-ref?expand=1#diff-0d06fdf33df5a300ffb1e9420b2ad526) for a minimal case triggering the issue that I was having.

Bonus change: I added `path` propagation while adding warnings so the reporting could also point the developer to a specific point of the specs