### PR TITLE
Fix test_complicated_refs broken after jsonschema-validator 3.0.0

### DIFF
--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -131,14 +131,11 @@ def test_complicated_refs():
 
     # Hokey verification but better than nothing:
     #   If all the files with $refs were ingested and validated and an
-    #   exception was not thrown, there should be 8 cached refs in the
-    #   resolver's store:
-    #
-    #   6 json files from tests/data/v2.0/tests_complicated_refs/*
-    #   1 yaml files from tests/data/v2.0/tests_complicated_refs/*
-    #   1 draft3 spec
-    #   1 draft4 spec
-    assert len(resolver.store) == 9
+    #   exception was not thrown, there should be 7 cached file references
+    #   in the resolver's store:
+    #       6 json files from tests/data/v2.0/tests_complicated_refs/*
+    #       1 yaml files from tests/data/v2.0/tests_complicated_refs/*
+    assert len([uri for uri in resolver.store.keys() if uri.startswith('file://')]) == 7
 
 
 def test_specs_with_discriminator():


### PR DESCRIPTION
Checking #116 I did noticed that our build was failing.
The failure has been caused by the release of `jsonschema-validator` v3.0.0.

The failing test is failing because the new version of the validator adds support for jsonschema draft6 and draft7 (which are stored into the `resolver.store`).
The test was verifying that all the expected `file://` references were loaded by the `resolver` but in doing it the test was keeping into account the 2 `http://` references (draft3 and draft4).

In order to fix the test and make it more stable for future versions of `jsonschema-validator` I modified the test to only care about the `file://` references