### PR TITLE
Fix assertion for checking the exception message on Python 3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 httpretty
 mock
-pytest
+pytest>=3.1.0

--- a/tests/validator12/validate_spec_test.py
+++ b/tests/validator12/validate_spec_test.py
@@ -66,9 +66,8 @@ def test_validate_parameter_type_file_in_body():
         'name': 'what',
         'type': 'File',
     }
-    with pytest.raises(SwaggerValidationError) as exc:
+    with pytest.raises(SwaggerValidationError, match='Type "File" is only valid for form parameters'):
         validate_parameter(parameter, [])
-    assert 'Type "File" is only valid for form parameters' in str(exc)
 
 
 def test_validate_data_type_is_model():
@@ -84,6 +83,5 @@ def test_validate_model_matches_id():
     model_name = "mymodel"
     model_ids = ""
 
-    with pytest.raises(SwaggerValidationError) as exc:
+    with pytest.raises(SwaggerValidationError, match='model name: mymodel does not match model id: mysupermodel'):
         validate_model(model, model_name, model_ids)
-    assert 'model name: mymodel does not match model id: mysupermodel' in str(exc)


### PR DESCRIPTION
The build has been failing due to these assertions not workin on Python 3:

```python
E       assert 'Type "File" is only valid for form parameters' in '<ExceptionInfo SwaggerValidationError tblen=3>'
E        +  where '<ExceptionInfo SwaggerValidationError tblen=3>' = str(<ExceptionInfo SwaggerValidationError tblen=3>)
```

The object the `raises` context manager provides is not the exception itself, but an `ExceptionInfo` object. I've opted drop the assertion line altogether instead of fixing it and use the [match kwarg for checking the message](https://docs.pytest.org/en/latest/reference.html#pytest-raises).