### PR TITLE
Show definition name in SwaggerValidationError

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -485,8 +485,8 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
         extra_props = list(set(required) - set(props))
         if extra_props:
             raise SwaggerValidationError(
-                "Required list has properties not defined: {}".format(
-                    extra_props
+                "Required list has properties not defined: {}. Definition is {}.".format(
+                    extra_props, def_name or '(no name)'
                 )
             )
 

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -469,7 +469,7 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
     swagger_type = definition.get('type')
     if isinstance(swagger_type, list):
         # not valid Swagger; see https://github.com/OAI/OpenAPI-Specification/issues/458
-        raise SwaggerValidationError('type must be a string; lists are not allowed (%s)' % swagger_type)
+        raise SwaggerValidationError('In definition of %s, type must be a string; lists are not allowed (%s)' % (def_name or '(no name)', swagger_type))
 
     if 'allOf' in definition:
         for idx, inner_definition in enumerate(definition['allOf']):
@@ -485,8 +485,8 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
         extra_props = list(set(required) - set(props))
         if extra_props:
             raise SwaggerValidationError(
-                "Required list has properties not defined: {}. Definition is {}.".format(
-                    extra_props, def_name or '(no name)'
+                "In definition of {}, required list has properties not defined: {}.".format(
+                    def_name or '(no name)', extra_props, 
                 )
             )
 
@@ -505,11 +505,11 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
         required_props, not_required_props = get_collapsed_properties_type_mappings(definition, deref)
         discriminator = definition['discriminator']
         if discriminator not in required_props and discriminator not in not_required_props:
-            raise SwaggerValidationError('discriminator (%s) must be defined in properties' % discriminator)
+            raise SwaggerValidationError('In definition of %s, discriminator (%s) must be defined in properties' % (def_name or '(no name)', discriminator))
         if discriminator not in required_props:
-            raise SwaggerValidationError('discriminator (%s) must be a required property' % discriminator)
+            raise SwaggerValidationError('In definition of %s, discriminator (%s) must be a required property' % (def_name or '(no name)', discriminator))
         if required_props[discriminator] != 'string':
-            raise SwaggerValidationError('discriminator (%s) must be a string property' % discriminator)
+            raise SwaggerValidationError('In definition of %s, discriminator (%s) must be a string property' % (def_name or '(no name)', discriminator))
 
 
 def validate_definitions(definitions, deref):

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -469,7 +469,7 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
     swagger_type = definition.get('type')
     if isinstance(swagger_type, list):
         # not valid Swagger; see https://github.com/OAI/OpenAPI-Specification/issues/458
-        raise SwaggerValidationError('In definition of %s, type must be a string; lists are not allowed (%s)' % (def_name or '(no name)', swagger_type))
+        raise SwaggerValidationError('In definition of {}, type must be a string; lists are not allowed ({})'.format(def_name or '(no name)', swagger_type))
 
     if 'allOf' in definition:
         for idx, inner_definition in enumerate(definition['allOf']):
@@ -486,7 +486,7 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
         if extra_props:
             raise SwaggerValidationError(
                 "In definition of {}, required list has properties not defined: {}.".format(
-                    def_name or '(no name)', extra_props, 
+                    def_name or '(no name)', extra_props,
                 )
             )
 
@@ -505,11 +505,11 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
         required_props, not_required_props = get_collapsed_properties_type_mappings(definition, deref)
         discriminator = definition['discriminator']
         if discriminator not in required_props and discriminator not in not_required_props:
-            raise SwaggerValidationError('In definition of %s, discriminator (%s) must be defined in properties' % (def_name or '(no name)', discriminator))
+            raise SwaggerValidationError('In definition of {}, discriminator ({}) must be defined in properties'.format(def_name or '(no name)', discriminator))
         if discriminator not in required_props:
-            raise SwaggerValidationError('In definition of %s, discriminator (%s) must be a required property' % (def_name or '(no name)', discriminator))
+            raise SwaggerValidationError('In definition of {}, discriminator ({}) must be a required property'.format(def_name or '(no name)', discriminator))
         if required_props[discriminator] != 'string':
-            raise SwaggerValidationError('In definition of %s, discriminator (%s) must be a string property' % (def_name or '(no name)', discriminator))
+            raise SwaggerValidationError('In definition of {}, discriminator ({}) must be a string property'.format(def_name or '(no name)', discriminator))
 
 
 def validate_definitions(definitions, deref):

--- a/tests/validator20/validate_definitions_test.py
+++ b/tests/validator20/validate_definitions_test.py
@@ -98,10 +98,13 @@ def test_multiple_types_fail():
         },
     }
 
-    with pytest.raises(SwaggerValidationError) as excinfo:
+    with pytest.raises(
+        SwaggerValidationError,
+        match=r"In definition of .*, type must be a string; lists are not allowed \(.*\)",
+    ) as excinfo:
         validate_definitions(definitions, lambda x: x)
 
-    assert excinfo.value.args[0].startswith('type must be a string; lists are not allowed')
+    assert str(definitions['definition_1']['type']) in str(excinfo.value)
 
 
 def test_type_array_with_items_succeed_validation():

--- a/tests/validator20/validate_rich_spec_test.py
+++ b/tests/validator20/validate_rich_spec_test.py
@@ -52,9 +52,12 @@ def test_failure_on_path_parameter_used_but_not_defined(swagger_spec):
 
 def test_failure_on_unresolvable_ref_of_props_required_list(swagger_spec):
     swagger_spec['definitions']['Pet']['required'].append('bla')
-    with pytest.raises(SwaggerValidationError) as exc_info:
+    with pytest.raises(
+        SwaggerValidationError,
+        match=r".*In definition of .*, required list has properties not defined: .*",
+    ) as exc_info:
         validate_spec(swagger_spec)
-    assert ("Required list has properties not defined: {}".format(['bla']) in str(exc_info.value))
+    assert str(['bla']) in str(exc_info.value)
 
 
 def test_failure_on_unresolvable_model_reference_from_model(swagger_spec):


### PR DESCRIPTION
`validator20.validate_definition()` does not include the name of the definition failing validation when raising SwaggerValidationErrors.

This pull request add the definition name to the exception, thereby making it easier to fix the schema error.