### PR TITLE
Tweak docs

### DIFF
--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import contextlib
+import functools
 import os
 import sys
 
@@ -23,6 +24,7 @@ TIMEOUT_SEC = 1
 
 
 def wrap_exception(method):
+    @functools.wraps(method)
     def wrapper(*args, **kwargs):
         try:
             return method(*args, **kwargs)

--- a/swagger_spec_validator/util.py
+++ b/swagger_spec_validator/util.py
@@ -50,10 +50,10 @@ def validate_spec_url(spec_url):
     """Validates a Swagger spec given its URL.
 
     :param spec_url:
-      For Swagger 1.2, this is the URL to the resource listing in api-docs.
-      For Swagger 2.0, this is the URL to swagger.json in api-docs. If given
-                       as `file://` this must be an absolute url for
-                       cross-refs to work correctly.
+        For Swagger 1.2, this is the URL to the resource listing in api-docs.
+        For Swagger 2.0, this is the URL to swagger.json in api-docs.
+        If given as ``file://``, this must be an absolute url for cross-refs
+        to work correctly.
     """
     spec_json = read_url(spec_url)
     validator = get_validator(spec_json, spec_url)


### PR DESCRIPTION
Sphinx wasn't rendering the docstring for `validate_spec_url`, since the `wrap_exception` decorator didn't preserve the docstring. This PR fixes that, as well as formatting issues with the docstring itself.

I'm not 100% sure about the original docstring's intent:

```
     For Swagger 1.2, this is the URL to the resource listing in api-docs.
     For Swagger 2.0, this is the URL to swagger.json in api-docs. If given
                      as `file://` this must be an absolute url for
                      cross-refs to work correctly.
```

Should those be three separate paragraphs, or is the "if given" part tacked onto the 2.0 note? I've just put all three sentences into one paragraph until hearing otherwise.