### PR TITLE
Test fixes

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+
+TESTS_BASE_PATH = os.path.abspath(os.path.dirname(__file__))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ def is_urlopen_error(exception):
         urlopen_error_str in str(exception)
         for urlopen_error_str in {
             '<urlopen error [Errno -2] Name or service not known>',
+            '<urlopen error [Errno -3] Temporary failure in name resolution>',
             '<urlopen error [Errno 8] nodename nor servname provided, or not known',
             '<urlopen error [Errno -5] No address associated with hostname>',
             '<urlopen error [Errno 11001] getaddrinfo failed>',

--- a/tests/validator12/validate_spec_test.py
+++ b/tests/validator12/validate_spec_test.py
@@ -4,8 +4,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
-
 import mock
 import pytest
 
@@ -17,10 +15,11 @@ from swagger_spec_validator.validator12 import validate_data_type
 from swagger_spec_validator.validator12 import validate_model
 from swagger_spec_validator.validator12 import validate_parameter
 from swagger_spec_validator.validator12 import validate_spec
+from tests import TESTS_BASE_PATH
 
 
-RESOURCE_LISTING_FILE = os.path.abspath('tests/data/v1.2/foo/swagger_api.json')
-API_DECLARATION_FILE = os.path.abspath('tests/data/v1.2/foo/foo.json')
+RESOURCE_LISTING_FILE = TESTS_BASE_PATH + '/data/v1.2/foo/swagger_api.json'
+API_DECLARATION_FILE = TESTS_BASE_PATH + '/data/v1.2/foo/foo.json'
 
 
 def get_resource_listing():

--- a/tests/validator12/validate_spec_url_test.py
+++ b/tests/validator12/validate_spec_url_test.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
-import os
 
 import mock
 import pytest
@@ -13,10 +12,12 @@ import pytest
 from swagger_spec_validator.common import get_uri_from_file_path
 from swagger_spec_validator.common import SwaggerValidationError
 from swagger_spec_validator.validator12 import validate_spec_url
+from tests import TESTS_BASE_PATH
 from tests.conftest import is_urlopen_error
 
-RESOURCE_LISTING_FILE = os.path.abspath('tests/data/v1.2/foo/swagger_api.json')
-API_DECLARATION_FILE = os.path.abspath('tests/data/v1.2/foo/foo.json')
+
+RESOURCE_LISTING_FILE = TESTS_BASE_PATH + '/data/v1.2/foo/swagger_api.json'
+API_DECLARATION_FILE = TESTS_BASE_PATH + '/data/v1.2/foo/foo.json'
 
 
 def read_contents(file_name):

--- a/tests/validator20/conftest.py
+++ b/tests/validator20/conftest.py
@@ -10,11 +10,12 @@ import os
 import pytest
 
 from swagger_spec_validator.common import get_uri_from_file_path
+from tests import TESTS_BASE_PATH
 
 
 @pytest.fixture(scope='session')
 def petstore_contents():
-    with open('./tests/data/v2.0/petstore.json') as f:
+    with open(TESTS_BASE_PATH + '/data/v2.0/petstore.json') as f:
         return f.read()
 
 


### PR DESCRIPTION
Fixed two issues with the tests:

- whether they passed or failed depended on them running from the correct folder.  This is now fixed.  You can run the test suite by simply typing `pytest` or by using the pycharm integrated runner.
- `is_urlopen_error` did not correctly identify the urlopen error on my ubuntu system.