### PR TITLE
perf: use cache instead of reloading schema files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
+        'functools32;python_version<"3"',
         'jsonschema',
         'pyyaml',
         'six',

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     from yaml import SafeLoader
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from functools32 import lru_cache
+
 
 TIMEOUT_SEC = 1
 
@@ -49,6 +54,11 @@ def read_file(file_path):
     :rtype: dict
     """
     return read_url(get_uri_from_file_path(file_path))
+
+
+@lru_cache(maxsize=12)
+def read_file_and_cache(file_path):
+    return read_file(file_path)
 
 
 def read_url(url, timeout=TIMEOUT_SEC):

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
+import time
 
 import pytest
 from jsonschema.validators import RefResolver
@@ -423,3 +424,11 @@ def test_highlight_inconsistent_schema_object_validation(minimal_swagger_dict, s
     minimal_swagger_dict.update(swagger_dict_override)
     with pytest.raises(SwaggerValidationError):
         validate_spec(minimal_swagger_dict)
+
+
+def test_validation_performance(minimal_swagger_dict):
+    start = time.time()
+    for _ in range(20):
+        validate_spec(minimal_swagger_dict)
+
+    assert time.time() - start < 1


### PR DESCRIPTION
Also dramatically speeds up the test suite.

Functools32 was already a dependency of jsonschema so this does not add a new dependency.

Addresses #129 