### PR TITLE
fix: additionalProperties and array items should be validated

### DIFF
--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -423,3 +423,27 @@ def test_highlight_inconsistent_schema_object_validation(minimal_swagger_dict, s
     minimal_swagger_dict.update(swagger_dict_override)
     with pytest.raises(SwaggerValidationError):
         validate_spec(minimal_swagger_dict)
+
+
+def test_additional_properties_validated(minimal_swagger_dict, default_checks_spec_dict):
+    invalid_spec = {'type': 'object', 'required': ['foo']}
+    minimal_swagger_dict['definitions']['injected_definition'] = invalid_spec
+
+    minimal_swagger_dict['definitions']['injected_definition'] = {
+        'type': 'object', 'additionalProperties': invalid_spec
+    }
+
+    with pytest.raises(SwaggerValidationError):
+        validate_spec(minimal_swagger_dict)
+
+
+def test_array_items_validated(minimal_swagger_dict, default_checks_spec_dict):
+    invalid_spec = {'type': 'object', 'required': ['foo']}
+    minimal_swagger_dict['definitions']['injected_definition'] = invalid_spec
+
+    minimal_swagger_dict['definitions']['injected_definition'] = {
+        'type': 'array', 'items': invalid_spec
+    }
+
+    with pytest.raises(SwaggerValidationError):
+        validate_spec(minimal_swagger_dict)


### PR DESCRIPTION
object definitions under object `additionalProperties` or under array `items` were not being validated.  

This adds that validation and test cases.