### PR TITLE
Add type check when validating definition

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -471,6 +471,10 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
             return
         visited_definitions_ids.add(id(definition))
 
+    if not isinstance(definition, dict):
+        raise SwaggerValidationError('Definition of {} must be a dict; got {}'.format(
+            def_name or '(no name)', type(definition)))
+
     swagger_type = definition.get('type')
     if isinstance(swagger_type, list):
         # not valid Swagger; see https://github.com/OAI/OpenAPI-Specification/issues/458

--- a/tests/validator20/validate_definitions_test.py
+++ b/tests/validator20/validate_definitions_test.py
@@ -134,6 +134,36 @@ def test_type_array_without_items_succeed_fails():
     assert str(excinfo.value) == 'Definition of type array must define `items` property (definition #/definitions/definition_1).'
 
 
+def test_type_object_additional_properties_dict_succeeds():
+    # See https://github.com/OAI/OpenAPI-Specification/issues/668
+    definitions = {
+        'example': {
+            'type': 'object',
+            'additionalProperties': {
+                'type': 'string',
+            },
+        },
+    }
+
+    validate_definitions(definitions, lambda x: x)
+
+
+def test_type_object_additional_properties_boolean_fails():
+    # See https://github.com/OAI/OpenAPI-Specification/issues/668
+    definitions = {
+        'example': {
+            'type': 'object',
+            'additionalProperties': False,
+        },
+    }
+
+    with pytest.raises(SwaggerValidationError) as exc_info:
+        validate_definitions(definitions, lambda x: x)
+
+    assert str(exc_info.value) == "Definition of #/definitions/example/additionalProperties " \
+                                  "must be a dict; got <class 'bool'>"
+
+
 def test_inline_model_is_not_valid_validation_fails():
     definitions = {
         'definition_1': {


### PR DESCRIPTION
This prevents an `AttributeError` when validating definitions like this:
```
type: object
properties: ...
additionalProperties: false
```