### PR TITLE
Fix: additionalProperties can be a boolean value

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -512,12 +512,13 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
             )
 
     if 'additionalProperties' in definition:
-        validate_definition(
-            definition=definition.get('additionalProperties'),
-            deref=deref,
-            def_name='{}/{}'.format(def_name, 'additionalProperties'),
-            visited_definitions_ids=visited_definitions_ids,
-        )
+        if definition.get('additionalProperties') not in (True, False):
+            validate_definition(
+                definition=definition.get('additionalProperties'),
+                deref=deref,
+                def_name='{}/additionalProperties'.format(def_name),
+                visited_definitions_ids=visited_definitions_ids,
+            )
 
     if 'discriminator' in definition:
         required_props, not_required_props = get_collapsed_properties_type_mappings(definition, deref)

--- a/tests/validator20/validate_spec_test.py
+++ b/tests/validator20/validate_spec_test.py
@@ -427,8 +427,6 @@ def test_highlight_inconsistent_schema_object_validation(minimal_swagger_dict, s
 
 def test_additional_properties_validated(minimal_swagger_dict, default_checks_spec_dict):
     invalid_spec = {'type': 'object', 'required': ['foo']}
-    minimal_swagger_dict['definitions']['injected_definition'] = invalid_spec
-
     minimal_swagger_dict['definitions']['injected_definition'] = {
         'type': 'object', 'additionalProperties': invalid_spec
     }
@@ -437,10 +435,16 @@ def test_additional_properties_validated(minimal_swagger_dict, default_checks_sp
         validate_spec(minimal_swagger_dict)
 
 
+def test_additional_properties_bool(minimal_swagger_dict, default_checks_spec_dict):
+    minimal_swagger_dict['definitions']['injected_definition'] = {
+        'type': 'object', 'additionalProperties': False,
+    }
+
+    validate_spec(minimal_swagger_dict)
+
+
 def test_array_items_validated(minimal_swagger_dict, default_checks_spec_dict):
     invalid_spec = {'type': 'object', 'required': ['foo']}
-    minimal_swagger_dict['definitions']['injected_definition'] = invalid_spec
-
     minimal_swagger_dict['definitions']['injected_definition'] = {
         'type': 'array', 'items': invalid_spec
     }


### PR DESCRIPTION
The validation introduced in 2.7.0 did not consider this case, I've fixed it and added a test. The test fails with 2.7.0 but passes with this change.

Fixes #137.