### PR TITLE
Fix recursive definition detection

### DIFF
--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import functools
+import json
 import logging
 import string
 import warnings
@@ -281,7 +282,7 @@ def validate_responses(api, http_verb, responses_dict, deref=None):
                 api=api,
                 status_code=response_status,
             ),
-            visited_definitions_ids=set(),
+            visited_definitions=set(),
         )
 
 
@@ -307,7 +308,7 @@ def validate_body_parameter(param, deref, def_name):
         definition=param['schema'],
         deref=deref,
         def_name='{}/schema'.format(def_name),
-        visited_definitions_ids=set(),
+        visited_definitions=set(),
     )
 
 
@@ -442,7 +443,7 @@ def validate_defaults_in_definition(definition_spec, deref):
         validate_property_default(property_spec, deref)
 
 
-def validate_arrays_in_definition(definition_spec, deref, def_name=None, visited_definitions_ids=None):
+def validate_arrays_in_definition(definition_spec, deref, def_name=None, visited_definitions=None):
     if definition_spec.get('type') == 'array':
         if 'items' not in definition_spec:
             raise SwaggerValidationError(
@@ -454,22 +455,24 @@ def validate_arrays_in_definition(definition_spec, deref, def_name=None, visited
             definition=definition_spec['items'],
             deref=deref,
             def_name='{}/items'.format(def_name),
-            visited_definitions_ids=visited_definitions_ids,
+            visited_definitions=visited_definitions,
         )
 
 
-def validate_definition(definition, deref, def_name=None, visited_definitions_ids=None):
+def validate_definition(definition, deref, def_name=None, visited_definitions=None):
     """
-    :param visited_definitions_ids: set of ids of already visited definitions (after dereference)
+    :param visited_definitions: set of ids of already visited definitions (after dereference)
                                     This is used to cut recursion in case of recursive definitions
-    :type visited_definitions_ids: set
+    :type visited_definitions: set
     """
-    definition = deref(definition)
-
-    if visited_definitions_ids is not None:
-        if id(definition) in visited_definitions_ids:
+    if visited_definitions is not None:
+        # Remove x-scope or else no two definitions will be the same
+        stripped_definition = json.dumps({key: definition[key] for key in definition if key != 'x-scope'}, sort_keys=True)
+        if stripped_definition in visited_definitions:
             return
-        visited_definitions_ids.add(id(definition))
+        visited_definitions.add(stripped_definition)
+
+    definition = deref(definition)
 
     swagger_type = definition.get('type')
     if isinstance(swagger_type, list):
@@ -482,7 +485,7 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
                 definition=inner_definition,
                 deref=deref,
                 def_name='{}/{}'.format(def_name, str(idx)),
-                visited_definitions_ids=visited_definitions_ids,
+                visited_definitions=visited_definitions,
             )
     else:
         required = definition.get('required', [])
@@ -500,7 +503,7 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
             definition_spec=definition,
             deref=deref,
             def_name=def_name,
-            visited_definitions_ids=visited_definitions_ids
+            visited_definitions=visited_definitions
         )
 
         for property_name, property_spec in iteritems(definition.get('properties', {})):
@@ -508,7 +511,7 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
                 definition=property_spec,
                 deref=deref,
                 def_name='{}/properties/{}'.format(def_name, property_name),
-                visited_definitions_ids=visited_definitions_ids,
+                visited_definitions=visited_definitions,
             )
 
     if 'additionalProperties' in definition:
@@ -517,7 +520,7 @@ def validate_definition(definition, deref, def_name=None, visited_definitions_id
                 definition=definition.get('additionalProperties'),
                 deref=deref,
                 def_name='{}/additionalProperties'.format(def_name),
-                visited_definitions_ids=visited_definitions_ids,
+                visited_definitions=visited_definitions,
             )
 
     if 'discriminator' in definition:
@@ -540,13 +543,13 @@ def validate_definitions(definitions, deref):
     :raises: :py:class:`swagger_spec_validator.SwaggerValidationError`
     :raises: :py:class:`jsonschema.exceptions.ValidationError`
     """
-    visited_definitions_ids = set()
+    visited_definitions = set()
     for def_name, definition in iteritems(definitions):
         validate_definition(
             definition=definition,
             deref=deref,
             def_name='#/definitions/{}'.format(def_name),
-            visited_definitions_ids=visited_definitions_ids,
+            visited_definitions=visited_definitions,
         )
 
 


### PR DESCRIPTION
We've recently had a recursive definition try to get validated (Apparently we've never had one that got hit by validation before?!) and it's throwing a `jsonschema` `Unresolveable Ref` error. Upon further inspection, we've found that the `deref` function in `validate_defintion` doesn't seem to be returning the old objects which makes the `id` checks in `visited_definitions_ids` not work either.
On top of that, we've found that upon a recursion, the 2nd instance of the object has a different (somehow stripped) `x-scope` than the 1st instance:
```
definitions:
  UserSurveyPossibleAnswer:
    type: object
    properties:
      followup_questions:
        type: array
        items:
          $ref: '#/definitions/UserSurveyQuestionObject'
    additionalProperties: false
    x-model: UserSurveyPossibleAnswer

  UserSurveyQuestionObject:
    type: object
    properties:
      answers:
        description: The set of answers from which users may choose.
        type: array
        items:
          $ref: '#/definitions/UserSurveyPossibleAnswer'
    additionalProperties: false
    x-model: UserSurveyQuestionObject

  UserSurveyObject:
    type: object
    properties:
      questions:
        description: Object containing survey questions objects.
        type: array
        items:
          $ref: '#/definitions/UserSurveyQuestionObject'
    additionalProperties: false
    x-model: UserSurveyObject

  UserSurveyQuestionResponse:
    type: object
    properties:
      survey:
        $ref: '#/definitions/UserSurveyObject'
    additionalProperties: false
    x-model: UserSurveyQuestionResponse


andytran@lolhost: ~/mobile_api (master) $ swagger-validate swagger.yaml --service mobile_api
Validating swagger.yaml
{'$ref': './foo.yaml#/definitions/UserSurveyQuestionResponse', 'x-scope': ['file:///swagger.yaml', 'file:///bar/foo.yaml']}
{'$ref': '#/definitions/UserSurveyObject', 'x-scope': ['file:///swagger.yaml', 'file:///bar/foo.yaml', 'file:///bar/baz.yaml#/definitions/UserSurveyQuestionResponse']}
{'$ref': '#/definitions/UserSurveyQuestionObject', 'x-scope': ['file:///swagger.yaml', 'file:///bar/foo.yaml', 'file:///bar/baz.yaml#/definitions/UserSurveyQuestionResponse', 'file:///bar/baz.yaml#/definitions/UserSurveyObject']}
{'$ref': '#/definitions/UserSurveyPossibleAnswer', 'x-scope': ['file:///swagger.yaml', 'file:///bar/foo.yaml', 'file:///bar/baz.yaml#/definitions/UserSurveyQuestionResponse', 'file:///bar/baz.yaml#/definitions/UserSurveyObject', 'file:///bar/baz.yaml#/definitions/UserSurveyQuestionObject']}
{'$ref': '#/definitions/UserSurveyQuestionObject'}
Unresolvable JSON pointer: 'definitions/UserSurveyQuestionObject'
```

This change makes it so that the visited key is the json dump of the definition without the `x-scope` parameter. Unfortunately this affects performance, and for one of our largest repos (mobile_api) it doubles the time for validation from ~5 seconds to ~10 seconds:
```
andytran@lolhost:~/mobile_api (master) $ time swagger-validate swagger.yaml --service mobile_api
Validating api_docs/swagger.yaml
real    0m9.599s
user    0m9.532s
sys     0m0.060s


(After removing the infinite recursion in UserSurvey)
andytran@lolhost:~/mobile_api (master) $ time swagger-validate swagger.yaml --service mobile_api
Validating api_docs/swagger.yaml


real    0m4.842s
user    0m4.784s
sys     0m0.056s
```

I'm sure there's a better, more performant approach, but this will at least get our validation checks to work again.