### PR TITLE
Fix build breakage due to zipp and python3.5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 httpretty
 mock
 pytest>=3.1.0
+# For python3.5 compatibility
+zipp<3.1.0

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import os
+import sys
 
 from setuptools import find_packages, setup
 
@@ -10,6 +11,16 @@ base_dir = os.path.dirname(__file__)
 about = {}
 with open(os.path.join(base_dir, "swagger_spec_validator", "__about__.py")) as f:
     exec(f.read(), about)
+
+
+install_requires = [
+    'jsonschema',
+    'pyyaml',
+    'six',
+]
+
+if sys.version_info <= (3, 0):
+    install_requires.append('pyrsistent<0.17.0')
 
 setup(
     name=about['__title__'],
@@ -29,11 +40,7 @@ setup(
         ],
     },
     include_package_data=True,
-    install_requires=[
-        'jsonschema',
-        'pyyaml',
-        'six',
-    ],
+    install_requires=install_requires,
     extra_dependencies={'python_version<"3"': ["functools32"]},
     license=about['__license__'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],

--- a/swagger_spec_validator/__about__.py
+++ b/swagger_spec_validator/__about__.py
@@ -14,7 +14,7 @@ __uri__ = "http://github.com/Yelp/swagger_spec_validator"
 
 __version__ = "2.7.3"
 
-__author__ = "John Billings"
-__email__ = "billings@yelp.com"
+__author__ = "Yelp"
+__email__ = "core-services@yelp.com"
 
 __license__ = "Apache License, Version 2.0"


### PR DESCRIPTION
Fixes
```
Collecting zipp>=0.5 (from importlib-metadata>=0.12; python_version < "3.8"->pytest>=3.1.0->-r requirements-dev.txt (line 3))

  Using cached https://pypi.yelpcorp.com/p/zipp-3.1.0-py3-none-any.whl

zipp requires Python '>=3.6' but the running Python is 3.5.2


ERROR: could not install deps [-rrequirements-dev.txt]; v = InvocationError('/ephemeral/jenkins/workspace/swagger_spec_validator-22679/.tox/py35-default/bin/pip install -rrequirements-dev.txt (see /ephemeral/jenkins/workspace/swagger_spec_validator-22679/.tox/py35-default/log/py35-default-1.log)', 1)
```