### PR TITLE
Use iteritems from six

### DIFF
--- a/swagger_spec_validator/ref_validators.py
+++ b/swagger_spec_validator/ref_validators.py
@@ -11,7 +11,6 @@ import logging
 import jsonschema
 import six
 from jsonschema import validators
-from jsonschema.compat import iteritems
 from jsonschema.validators import Draft4Validator
 from jsonschema.validators import RefResolver
 
@@ -88,7 +87,7 @@ def create_dereffing_validator(instance_resolver):
             visited_refs=visited_refs,
             default_validator_callable=v,
         ) if k in validators_to_bound else v
-        for k, v in iteritems(Draft4Validator.VALIDATORS)
+        for k, v in six.iteritems(Draft4Validator.VALIDATORS)
     }
 
     return validators.extend(Draft4Validator, bound_validators)


### PR DESCRIPTION
Hi there,
swagger_spec_validator uses compat module from jsonschema.
Jsonschema team removed this module in 4.X.X:
https://github.com/Julian/jsonschema/commit/1d7711702f8b5f5396f4317d2a409fcf901ab8d3#diff-cdc6b1a8a01e77eecdfa0d2559447e4ca46a014edaab1f604db31db783fed8bc

It looks like that they are going to get rid of python2.7.

