### PR TITLE
Edit jsonschema version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(base_dir, "swagger_spec_validator", "__about__.py")) as f
 
 
 install_requires = [
-    'jsonschema',
+    'jsonschema<4',
     'pyyaml',
     'six',
 ]


### PR DESCRIPTION
```
>>> import swagger_spec_validator
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/xing/Workspace/opensource/swagger_spec_validator/swagger_spec_validator/__init__.py", line 8, in <module>
    from swagger_spec_validator.util import validate_spec_url
  File "/home/xing/Workspace/opensource/swagger_spec_validator/swagger_spec_validator/util.py", line 9, in <module>
    from swagger_spec_validator import validator12
  File "/home/xing/Workspace/opensource/swagger_spec_validator/swagger_spec_validator/validator12.py", line 29, in <module>
    from swagger_spec_validator.ref_validators import default_handlers
  File "/home/xing/Workspace/opensource/swagger_spec_validator/swagger_spec_validator/ref_validators.py", line 14, in <module>
    from jsonschema.compat import iteritems
ModuleNotFoundError: No module named 'jsonschema.compat'
```
Json schema just release version 4.0 today and cause backward incompatible.