### PR TITLE
Add py typed marker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 Changelog
 =========
+3.0.1 (2022-10-19)
+------------------
+- Add py.typed marker - PR #158
+- Enforce python_requires>=3.7
+
 3.0.0 (2022-10-19)
 ------------------
 - Add type annotations - PR #157

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             "py.typed",
         ],
     },
+    python_requires=">=3.7",
     include_package_data=True,
     install_requires=install_requires,
     license=about["__license__"],

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "swagger_spec_validator": [
             "swagger_spec_validator/schemas/v1.2/*",
             "swagger_spec_validator/schemas/v2.0/*",
+            "py.typed",
         ],
     },
     include_package_data=True,

--- a/swagger_spec_validator/__about__.py
+++ b/swagger_spec_validator/__about__.py
@@ -12,7 +12,7 @@ __title__ = "swagger-spec-validator"
 __summary__ = "Validation of Swagger specifications"
 __uri__ = "http://github.com/Yelp/swagger_spec_validator"
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 __author__ = "Yelp"
 __email__ = "core-services@yelp.com"


### PR DESCRIPTION
Forgot to add the py.typed marker in #157.

Also added `python_requires>=3.7` to enforce python versions.