### PR TITLE
Included typing-extensions to list of requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open(os.path.join(base_dir, "swagger_spec_validator", "__about__.py")) as f
 install_requires = [
     "jsonschema",
     "pyyaml",
+    "typing-extensions",
 ]
 
 

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -7,7 +7,6 @@ import sys
 from functools import lru_cache
 from typing import Any
 from typing import Callable
-from typing import Tuple
 from typing import TypeVar
 from urllib.parse import urljoin
 from urllib.request import pathname2url


### PR DESCRIPTION
With the upgrade to version 3.0, an new package requirement was added but not included in the form of `typing_extensions`. fixes: #161

**Example of current error**
```
Python 3.9.13 (main, Jul  7 2022, 09:29:37)
[Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from swagger_spec_validator.common import SwaggerValidationError
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/.venv/lib/python3.9/site-packages/swagger_spec_validator/__init__.py", line 1, in <module>
    from swagger_spec_validator.common import SwaggerValidationError
  File "~/.venv/lib/python3.9/site-packages/swagger_spec_validator/common.py", line 18, in <module>
    from typing_extensions import ParamSpec
ModuleNotFoundError: No module named 'typing_extensions'
```

**Are there other solutions**
Yes, you could remove the reference to `ParamSpec` and typehint the section of code as follows

```
def wrap_exception(method: Callable[..., T]) -> Callable[..., T]:
    @functools.wraps(method)
    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
        try:
            return method(*args, **kwargs)
        except Exception as e:
            raise SwaggerValidationError(str(e), e).with_traceback(sys.exc_info()[2])

    return wrapper
```