### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
         python-version:
           - '3.7'
           - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -13,7 +13,7 @@ from urllib.request import pathname2url
 from urllib.request import urlopen
 
 import yaml
-from pkg_resources import resource_filename
+import importlib.resources
 from typing_extensions import ParamSpec
 
 try:
@@ -55,8 +55,9 @@ def read_file(file_path: str) -> dict[str, Any]:
 
 @lru_cache()
 def read_resource_file(resource_path: str) -> tuple[dict[str, Any], str]:
-    schema_path = resource_filename("swagger_spec_validator", resource_path)
-    return read_file(schema_path), schema_path
+    ref = importlib.resources.files('swagger_spec_validator') / resource_path
+    with importlib.resources.as_file(ref) as path:
+        return read_file(path), path
 
 
 def read_url(url: str, timeout: float = TIMEOUT_SEC) -> dict[str, Any]:

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -1,7 +1,7 @@
 import uuid
 from unittest import mock
 
-from pkg_resources import resource_filename
+import importlib.resources
 
 from swagger_spec_validator.common import read_file
 from swagger_spec_validator.common import read_resource_file
@@ -19,5 +19,5 @@ def test_read_resource_file(monkeypatch):
         read_resource_file(resource_path)
 
     m.assert_called_once_with(
-        resource_filename("swagger_spec_validator", resource_path)
+        importlib.resources.files("swagger_spec_validator")
     )


### PR DESCRIPTION
This PR adds support up to Python 3.12. `pkg_resources` is no longer accessible by default in Python 3.12, which means this library is incompatible with Python 3.12 without `setuptools` installed. This PR moves from using `pkg_resources` to `importlib.resources` which is the intended way of replacing the resources API of pgk_resources. See [here](https://importlib-resources.readthedocs.io/en/latest/migration.html).