### PR TITLE
Run github ci workflow for more scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,15 @@
 ---
 name: build
-on: push
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*.*
+  pull_request:
+  release:
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The CI workflow only runs on pushes, but this misses out on several other scenarios

## Solution

* Run github for master branch, tags, pull-requests, release