### PR TITLE
use importlib_resources to fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - run: tox -e py
 
   misc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
@@ -43,6 +42,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.12
       - run: pip install tox
       - run: tox -e ${{ matrix.tox }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.12
 
     - name: Install Python dependencies
       run: pip install wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     rev: v3.1.0
     hooks:
     -   id: pyupgrade
+        args: ["--py38-plus"]
 -   repo: http://github.com/psf/black
     rev: 22.10.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,5 +29,3 @@ repos:
     rev: 22.10.0
     hooks:
     -   id: black
-        language_version: python3.7
-        args: [--target-version, py37]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 show_error_context = true
 show_column_numbers = true
 warn_unused_ignores = true

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
             "swagger_spec_validator/py.typed",
         ],
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     include_package_data=True,
     install_requires=install_requires,
     license=about["__license__"],

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = [
     "jsonschema",
     "pyyaml",
     "typing-extensions",
+    "importlib-resources >= 1.3",
 ]
 
 

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -53,7 +53,7 @@ def read_file(file_path: str) -> dict[str, Any]:
     return read_url(get_uri_from_file_path(file_path))
 
 
-@lru_cache()
+@lru_cache
 def read_resource_file(resource_path: str) -> tuple[dict[str, Any], str]:
     ref = importlib_resources.files("swagger_spec_validator") / resource_path
     with importlib_resources.as_file(ref) as path:

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -12,8 +12,8 @@ from urllib.parse import urljoin
 from urllib.request import pathname2url
 from urllib.request import urlopen
 
+import importlib_resources
 import yaml
-import importlib.resources
 from typing_extensions import ParamSpec
 
 try:
@@ -55,8 +55,8 @@ def read_file(file_path: str) -> dict[str, Any]:
 
 @lru_cache()
 def read_resource_file(resource_path: str) -> tuple[dict[str, Any], str]:
-    ref = importlib.resources.files('swagger_spec_validator') / resource_path
-    with importlib.resources.as_file(ref) as path:
+    ref = importlib_resources.files("swagger_spec_validator") / resource_path
+    with importlib_resources.as_file(ref) as path:
         return read_file(path), path
 
 

--- a/swagger_spec_validator/validator12.py
+++ b/swagger_spec_validator/validator12.py
@@ -190,7 +190,7 @@ def validate_model(
         except SwaggerValidationError as e:
             # Add more context to the exception and re-raise
             raise SwaggerValidationError(
-                'Model "{}", property "{}": {}'.format(model_name, prop_name, str(e))
+                f'Model "{model_name}", property "{prop_name}": {str(e)}'
             )
 
 

--- a/swagger_spec_validator/validator20.py
+++ b/swagger_spec_validator/validator20.py
@@ -350,7 +350,7 @@ def validate_body_parameter(
     validate_definition(
         definition=param["schema"],
         deref=deref,
-        def_name="{}/schema".format(def_name),
+        def_name=f"{def_name}/schema",
         visited_definitions=set(),
     )
 
@@ -403,7 +403,7 @@ def validate_apis(apis: dict[str, Any], deref: Callable) -> None:
             if operation_id is not None:
                 if operation_id in operation_id_set:
                     raise SwaggerValidationError(
-                        "Duplicate operationId: {}".format(operation_id)
+                        f"Duplicate operationId: {operation_id}"
                     )
                 operation_id_set.add(operation_id)
 
@@ -508,13 +508,13 @@ def validate_arrays_in_definition(
         if "items" not in definition_spec:
             raise SwaggerValidationError(
                 "Definition of type array must define `items` property{}.".format(
-                    "" if not def_name else " (definition {})".format(def_name),
+                    "" if not def_name else f" (definition {def_name})",
                 ),
             )
         validate_definition(
             definition=definition_spec["items"],
             deref=deref,
-            def_name="{}/items".format(def_name),
+            def_name=f"{def_name}/items",
             visited_definitions=visited_definitions,
         )
 
@@ -556,7 +556,7 @@ def validate_definition(
             validate_definition(
                 definition=inner_definition,
                 deref=deref,
-                def_name="{}/{}".format(def_name, str(idx)),
+                def_name=f"{def_name}/{str(idx)}",
                 visited_definitions=visited_definitions,
             )
     else:
@@ -583,7 +583,7 @@ def validate_definition(
             validate_definition(
                 definition=property_spec,
                 deref=deref,
-                def_name="{}/properties/{}".format(def_name, property_name),
+                def_name=f"{def_name}/properties/{property_name}",
                 visited_definitions=visited_definitions,
             )
 
@@ -592,7 +592,7 @@ def validate_definition(
             validate_definition(
                 definition=cast("dict[str, Any]", definition["additionalProperties"]),
                 deref=deref,
-                def_name="{}/additionalProperties".format(def_name),
+                def_name=f"{def_name}/additionalProperties",
                 visited_definitions=visited_definitions,
             )
 
@@ -638,7 +638,7 @@ def validate_definitions(definitions: dict[str, Any], deref: Callable) -> None:
         validate_definition(
             definition=definition,
             deref=deref,
-            def_name="#/definitions/{}".format(def_name),
+            def_name=f"#/definitions/{def_name}",
             visited_definitions=visited_definitions,
         )
 
@@ -648,7 +648,7 @@ def validate_parameters(parameters: dict[str, Any], deref: Callable) -> None:
         validate_parameter(
             param=param_spec,
             deref=deref,
-            def_name="#/parameters/{}".format(param_name),
+            def_name=f"#/parameters/{param_name}",
         )
 
 
@@ -680,7 +680,7 @@ def validate_duplicate_param(params: list[Any], deref: Callable) -> None:
         param = deref(param)
         param_key = (param["name"], param["in"])
         if param_key in seen:
-            raise SwaggerValidationError("{}: {}".format(msg, param_key))
+            raise SwaggerValidationError(f"{msg}: {param_key}")
         seen.add(param_key)
 
 

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -1,7 +1,7 @@
 import uuid
 from unittest import mock
 
-import importlib.resources
+import importlib_resources
 
 from swagger_spec_validator.common import read_file
 from swagger_spec_validator.common import read_resource_file
@@ -19,5 +19,5 @@ def test_read_resource_file(monkeypatch):
         read_resource_file(resource_path)
 
     m.assert_called_once_with(
-        importlib.resources.files("swagger_spec_validator")
+        importlib_resources.files("swagger_spec_validator") / resource_path
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,pre-commit,cover
+envlist = py38,py310,pre-commit,cover
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,pre-commit,cover
+envlist = py38,pre-commit,cover
 
 [testenv]
 deps =


### PR DESCRIPTION
Not sure why this didn't get noticed before but `importlib.resources.{as_file,files}` were added in python 3.9, but we supported 3.7. I dropped python 3.7 since it's EOL, but 3.8 is not so I migrated this to use `importlib_resources`. I also added python 3.10 to the local build for good measure.

Some other general TLC:
- upgrade setup-python GHA usages to be python 3.12 and a supported ubuntu (noble)
- enable and run `pyupgrade --py38-plus`