### PR TITLE
Use importlib.resources if possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from setuptools import find_packages, setup
 
@@ -13,8 +14,10 @@ install_requires = [
     "jsonschema",
     "pyyaml",
     "typing-extensions",
-    "importlib-resources >= 1.3",
 ]
+
+if sys.version_info < (3, 9, 0):
+    install_requires.append("importlib-resources >= 1.3")
 
 
 setup(

--- a/swagger_spec_validator/common.py
+++ b/swagger_spec_validator/common.py
@@ -12,7 +12,13 @@ from urllib.parse import urljoin
 from urllib.request import pathname2url
 from urllib.request import urlopen
 
-import importlib_resources
+try:
+    import importlib.resources
+except ImportError:
+    import importlib
+    import importlib_resources
+    importlib.resources = importlib_resources
+
 import yaml
 from typing_extensions import ParamSpec
 
@@ -55,8 +61,8 @@ def read_file(file_path: str) -> dict[str, Any]:
 
 @lru_cache
 def read_resource_file(resource_path: str) -> tuple[dict[str, Any], str]:
-    ref = importlib_resources.files("swagger_spec_validator") / resource_path
-    with importlib_resources.as_file(ref) as path:
+    ref = importlib.resources.files("swagger_spec_validator") / resource_path
+    with importlib.resources.as_file(ref) as path:
         return read_file(path), path
 
 

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -1,7 +1,12 @@
 import uuid
 from unittest import mock
 
-import importlib_resources
+try:
+    import importlib.resources
+except ImportError:
+    import importlib
+    import importlib_resources
+    importlib.resources = importlib_resources
 
 from swagger_spec_validator.common import read_file
 from swagger_spec_validator.common import read_resource_file
@@ -19,5 +24,5 @@ def test_read_resource_file(monkeypatch):
         read_resource_file(resource_path)
 
     m.assert_called_once_with(
-        importlib_resources.files("swagger_spec_validator") / resource_path
+        importlib.resources.files("swagger_spec_validator") / resource_path
     )


### PR DESCRIPTION
~~The importlib_resources package isn’t required from Python 3.7 on, it’s available in importlib.resources.~~

The importlib_resources package is only required for Python < 3.9.